### PR TITLE
Make 'common' project optional via CMT configuration

### DIFF
--- a/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
+++ b/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
@@ -2,7 +2,6 @@ package sbtstudent
 
 import sbt.Keys._
 import sbt.{Def, _}
-import stbstudent.MPSelection
 
 import scala.Console
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -13,6 +13,10 @@ studentify {
   # in the context of its application (like "step", "demo_step", ...)
   exercise-project-prefix = exercise
 
+  # The default setting of `common-project-enabled` is to aggregate
+  # all code in the `common` project into all exercises
+  common-project-enabled = true
+
   # Studentify mode
   studentify-mode-select = classic
 

--- a/src/main/scala/com/lightbend/coursegentools/MainSettings.scala
+++ b/src/main/scala/com/lightbend/coursegentools/MainSettings.scala
@@ -55,6 +55,8 @@ class MainSettings(mainRepo: File, optConfigurationFile: Option[String]) {
   val testCodeFolders: List[String] =
     config.getStringList("studentify.test-code-folders").asScala.toList
 
+  val commonProjectEnabled: Boolean = config.getBoolean("studentify.common-project-enabled")
+
   val exerciseProjectPrefix: String = config.getString("studentify.exercise-project-prefix")
 
   val studentifyModeSelect: String = config.getString("studentify.studentify-mode-select")


### PR DESCRIPTION
- Default behavior is to asume a `common` project is present
- Disable `common` project by setting `studentify.common-project-enabled`
  to `false`