### PR TITLE
Handle .ignore files properly when linearizing or studentifying a pro…

### DIFF
--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -238,7 +238,7 @@ object Helpers {
       .runAndExitIfFailed(toConsoleRed(s"Failed to initialize linearized git repository in ${linearizedProject.getPath}"))
   }
 
-  def addGitignoreFromMaster(mainRepo: File, linearizedProject: File): Unit = {
+  def addGitignoreFromMain(mainRepo: File, linearizedProject: File): Unit = {
     val gitignoreFile = new File(mainRepo, ".gitignore")
     if (gitignoreFile.exists())
       sbtio.copyFile(gitignoreFile, new File(linearizedProject, ".gitignore"))

--- a/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -238,6 +238,12 @@ object Helpers {
       .runAndExitIfFailed(toConsoleRed(s"Failed to initialize linearized git repository in ${linearizedProject.getPath}"))
   }
 
+  def addGitignoreFromMaster(mainRepo: File, linearizedProject: File): Unit = {
+    val gitignoreFile = new File(mainRepo, ".gitignore")
+    if (gitignoreFile.exists())
+      sbtio.copyFile(gitignoreFile, new File(linearizedProject, ".gitignore"))
+  }
+
   def removeExercisesFromCleanMain(cleanMainRepo: File, exercises: Seq[String])(implicit eofe: ExitOnFirstError): Unit = {
     for {
       exercise <- exercises

--- a/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -69,7 +69,7 @@ object Linearize {
     cleanUp(List(".git", "navigation.sbt"), linearizedProject)
 
     removeExercisesFromCleanMain(linearizedProject, exercises)
-    addGitignoreFromMaster(mainRepo, linearizedProject)
+    addGitignoreFromMain(mainRepo, linearizedProject)
     stageFirstExercise(exercises.head, relativeCleanMainRepo, linearizedProject)
     initializeGitRepo(linearizedProject)
     commitFirstExercise(exercises.head, linearizedProject)

--- a/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -69,6 +69,7 @@ object Linearize {
     cleanUp(List(".git", "navigation.sbt"), linearizedProject)
 
     removeExercisesFromCleanMain(linearizedProject, exercises)
+    addGitignoreFromMaster(mainRepo, linearizedProject)
     stageFirstExercise(exercises.head, relativeCleanMainRepo, linearizedProject)
     initializeGitRepo(linearizedProject)
     commitFirstExercise(exercises.head, linearizedProject)

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -86,7 +86,7 @@ object Studentify {
   def initialiseAsGit(mainRepo: File, studentifiedRepo: File): Unit = {
     import ProcessDSL._
 
-    Helpers.addGitignoreFromMaster(mainRepo, studentifiedRepo)
+    Helpers.addGitignoreFromMain(mainRepo, studentifiedRepo)
     s"git init"
       .toProcessCmd(workingDir = studentifiedRepo)
       .runAndExitIfFailed(toConsoleRed(s"'git init' failed on ${studentifiedRepo.getAbsolutePath}"))

--- a/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -80,61 +80,13 @@ object Studentify {
     loadStudentSettings(mainRepo, targetCourseFolder)
     cleanUp(config.studentifyFilesToCleanUp, targetCourseFolder)
     sbtio.delete(tmpDir)
-    if (initAsGitRepo) initialiseAsGit(targetCourseFolder)
+    if (initAsGitRepo) initialiseAsGit(mainRepo, targetCourseFolder)
   }
 
-  def defaultGitIgnoreContent: String =
-    s"""*.class
-       |*.log
-       |.bookmark
-       |
-       |# VSCode specific
-       |.vscode
-       |*.code-workspace
-       |
-       |# Metals/Bloop specific
-       |.bloop/
-       |.metals/
-       |.swp
-       |project/metals.sbt
-       |
-       |# sbt specific
-       |.cache/
-       |.history/
-       |.lib/
-       |dist/*
-       |target/
-       |lib_managed/
-       |src_managed/
-       |project/boot/
-       |project/plugins/project/
-       |
-       |# Scala-IDE specific
-       |.scala_dependencies
-       |.worksheet
-       |.target
-       |.cache
-       |.classpath
-       |.project
-       |.settings/
-       |
-       |# Intellij specific
-       |*.iml
-       |*.idea/
-       |*.idea_modules/
-       |
-       |# Sublime specific
-       |*.sublime-project
-       |*.sublime-workspace
-       |
-       |# OS specific
-       |.DS_Store
-       """.stripMargin
-
-  def initialiseAsGit(studentifiedRepo: File): Unit = {
+  def initialiseAsGit(mainRepo: File, studentifiedRepo: File): Unit = {
     import ProcessDSL._
 
-    dumpStringToFile(defaultGitIgnoreContent, new File(studentifiedRepo, ".gitignore").getPath)
+    Helpers.addGitignoreFromMaster(mainRepo, studentifiedRepo)
     s"git init"
       .toProcessCmd(workingDir = studentifiedRepo)
       .runAndExitIfFailed(toConsoleRed(s"'git init' failed on ${studentifiedRepo.getAbsolutePath}"))


### PR DESCRIPTION
…ject

Fixes #96

- When linearizing a main repo, the .gitnore file in the main repo's root
  folder should be copied to the root folder of the linearized project
- The same thing is done when studentifying a main repo if the `-g` option
  is passed to `studentify`