### PR TITLE
Fix sbt shellPrompt rendering failure on Play projects

### DIFF
--- a/course-templates/dotty-cmt-template-common/project/StudentCommandsPlugin.scala
+++ b/course-templates/dotty-cmt-template-common/project/StudentCommandsPlugin.scala
@@ -55,13 +55,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCMTPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/course-templates/dotty-cmt-template-no-common/project/StudentCommandsPlugin.scala
+++ b/course-templates/dotty-cmt-template-no-common/project/StudentCommandsPlugin.scala
@@ -55,13 +55,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCMTPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/course-templates/play-cmt-template-no-common/project/CommonSettings.scala
+++ b/course-templates/play-cmt-template-no-common/project/CommonSettings.scala
@@ -1,6 +1,7 @@
 import sbt.Keys._
 import sbt._
 import sbtstudent.AdditionalSettings
+import sbtstudent.StudentCommandsPlugin._
 
 object CommonSettings {
   lazy val commonSettings = Seq(
@@ -9,7 +10,8 @@ object CommonSettings {
     Test / unmanagedSourceDirectories := List((scalaSource in Test).value, (javaSource in Test).value),
     Test / logBuffered := false,
     Test / parallelExecution := false,
-    libraryDependencies ++= Dependencies.dependencies
+    libraryDependencies ++= Dependencies.dependencies,
+    shellPrompt := (state => renderCmtPrompt(state))
   ) ++
     AdditionalSettings.initialCmdsConsole ++
     AdditionalSettings.initialCmdsTestConsole ++

--- a/course-templates/play-cmt-template-no-common/project/CommonSettings.scala
+++ b/course-templates/play-cmt-template-no-common/project/CommonSettings.scala
@@ -11,7 +11,7 @@ object CommonSettings {
     Test / logBuffered := false,
     Test / parallelExecution := false,
     libraryDependencies ++= Dependencies.dependencies,
-    shellPrompt := (state => renderCmtPrompt(state))
+    shellPrompt := (state => renderCMTPrompt(state))
   ) ++
     AdditionalSettings.initialCmdsConsole ++
     AdditionalSettings.initialCmdsTestConsole ++

--- a/course-templates/play-cmt-template-no-common/project/StudentCommandsPlugin.scala
+++ b/course-templates/play-cmt-template-no-common/project/StudentCommandsPlugin.scala
@@ -55,7 +55,7 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  def renderCmtPrompt(state: State) = {
+  def renderCMTPrompt(state: State) = {
     val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
     val manRmnd = Console.GREEN + "man [e]" + Console.RESET
     val prjNbrNme = extractProjectName(state)
@@ -64,6 +64,6 @@ object StudentCommandsPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state => renderCmtPrompt(state)}
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/course-templates/play-cmt-template-no-common/project/StudentCommandsPlugin.scala
+++ b/course-templates/play-cmt-template-no-common/project/StudentCommandsPlugin.scala
@@ -55,13 +55,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCmtPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCmtPrompt(state)}
     )
 }

--- a/course-templates/scala-cmt-template-common/project/StudentCommandsPlugin.scala
+++ b/course-templates/scala-cmt-template-common/project/StudentCommandsPlugin.scala
@@ -55,13 +55,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCMTPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/course-templates/scala-cmt-template-no-common/project/StudentCommandsPlugin.scala
+++ b/course-templates/scala-cmt-template-no-common/project/StudentCommandsPlugin.scala
@@ -55,13 +55,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCMTPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/sbtLinearizeCommands/Man.scala.template
+++ b/sbtLinearizeCommands/Man.scala.template
@@ -19,10 +19,10 @@ object Man {
   def man: Command = Command("man")(_ => optArg) { (state, arg) =>
     arg match {
       case Some(a) if a == "e" =>
-        val base: File = Project.extract(state).get(sourceDirectory)
+        val base: File = Project.extract(state).get(baseDirectory)
         val readmeFile: File = {
           val bPath = new File(base, "/test/resources/README.md")
-          if (bPath.isFile) bPath else new File(base, "../README.md")
+          if (bPath.isFile) bPath else new File(base, "README.md")
         }
         printOut(readmeFile)
         Console.print("\n")

--- a/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
+++ b/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
@@ -35,13 +35,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCmtPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCmtPrompt(state)}
     )
 }

--- a/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
+++ b/sbtLinearizeCommands/StudentCommandsPlugin.scala.template
@@ -35,7 +35,7 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  def renderCmtPrompt(state: State) = {
+  def renderCMTPrompt(state: State) = {
     val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
     val manRmnd = Console.GREEN + "man [e]" + Console.RESET
     val prjNbrNme = extractProjectName(state)
@@ -44,6 +44,6 @@ object StudentCommandsPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state => renderCmtPrompt(state)}
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/sbtMainCommands/Man.scala.template
+++ b/sbtMainCommands/Man.scala.template
@@ -19,10 +19,10 @@ object Man {
   def man: Command = Command("man")(_ => optArg) { (state, arg) =>
     arg match {
       case Some(a) if a == "e" =>
-        val base: File = Project.extract(state).get(sourceDirectory)
+        val base: File = Project.extract(state).get(baseDirectory)
         val readmeFile: File = {
           val bPath = new File(base, "/test/resources/README.md")
-          if (bPath.isFile) bPath else new File(base, "../README.md")
+          if (bPath.isFile) bPath else new File(base, "README.md")
         }
         printOut(readmeFile)
         Console.print("\n")

--- a/sbtMainCommands/StudentCommandsPlugin.scala.template
+++ b/sbtMainCommands/StudentCommandsPlugin.scala.template
@@ -36,7 +36,7 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  def renderCmtPrompt(state: State) = {
+  def renderCMTPrompt(state: State) = {
     val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
     val manRmnd = Console.GREEN + "man [e]" + Console.RESET
     val prjNbrNme = extractProjectName(state)
@@ -45,6 +45,6 @@ object StudentCommandsPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state => renderCmtPrompt(state)}
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }

--- a/sbtMainCommands/StudentCommandsPlugin.scala.template
+++ b/sbtMainCommands/StudentCommandsPlugin.scala.template
@@ -36,13 +36,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
+  def renderCmtPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
+
+  override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state =>
-        val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = Console.GREEN + "man [e]" + Console.RESET
-        val prjNbrNme = extractProjectName(state)
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+      shellPrompt := { state => renderCmtPrompt(state)}
     )
 }

--- a/sbtStudentCommands/StudentCommandsPlugin.scala.template
+++ b/sbtStudentCommands/StudentCommandsPlugin.scala.template
@@ -42,17 +42,15 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  override lazy val projectSettings: Seq[Def.Setting[State => String]] =
-    Seq(
-      shellPrompt := { state =>
-        val promptCourseNameColor = SSettings.consoleColorMap(SSettings.promptCourseNameColor)
-        val promptExerciseColor = SSettings.consoleColorMap(SSettings.promptExerciseColor)
-        val promptManColor = SSettings.consoleColorMap(SSettings.promptManColor)
-        val exercise = promptExerciseColor + extractCurrentExerciseDesc(state) + Console.RESET
-        val manRmnd = promptManColor + "man [e]" + Console.RESET
-        val prjNbrNme = promptCourseNameColor + extractProjectName(state) + Console.RESET
+  def renderCmtPrompt(state: State) = {
+    val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
+    val manRmnd = Console.GREEN + "man [e]" + Console.RESET
+    val prjNbrNme = extractProjectName(state)
+    s"$manRmnd > $prjNbrNme > $exercise > "
+  }
 
-        s"$manRmnd > $prjNbrNme > $exercise > "
-      }
+  override def projectSettings: Seq[Def.Setting[State => String]] =
+    Seq(
+      shellPrompt := { state => renderCmtPrompt(state)}
     )
 }

--- a/sbtStudentCommands/StudentCommandsPlugin.scala.template
+++ b/sbtStudentCommands/StudentCommandsPlugin.scala.template
@@ -42,7 +42,7 @@ object StudentCommandsPlugin extends AutoPlugin {
     IO.readLines(new sbt.File(new sbt.File(Project.extract(state).structure.root), ".courseName")).head
   }
 
-  def renderCmtPrompt(state: State) = {
+  def renderCMTPrompt(state: State) = {
     val exercise = Console.GREEN + extractCurrentExerciseDesc(state) + Console.RESET
     val manRmnd = Console.GREEN + "man [e]" + Console.RESET
     val prjNbrNme = extractProjectName(state)
@@ -51,6 +51,6 @@ object StudentCommandsPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[State => String]] =
     Seq(
-      shellPrompt := { state => renderCmtPrompt(state)}
+      shellPrompt := { state => renderCMTPrompt(state)}
     )
 }


### PR DESCRIPTION
Fixes #110 

Add `shellPrompt` settings to project level sbt config.