### PR TITLE
Setup release pipeline using github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags: ['*']
   pull_request:
 
 jobs:
@@ -57,3 +58,78 @@ jobs:
           for ts in $(ls testScripts/*.sh);do
           bash $ts || break
           done
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [run-tests]
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+    
+    steps:
+      - name: Checkout Course Management Tools Repo
+        uses: actions/checkout@v2
+        with:
+          path: CMT
+          fetch-depth: 0
+    
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+    
+      - name: Cache Ivy
+        uses: actions/cache@v2
+        with:
+          path: ~/.ivy2/cache
+          key: ${{ runner.os }}-ivy--${{ hashFiles('**/build.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-ivy-
+            ${{ runner.os }}-
+            
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: ~/.sbt            
+          key: ${{ runner.os }}-sbt-${{ hashFiles('project/**') }}
+          restore-keys: |
+            ${{ runner.os }}-sbt-
+            ${{ runner.os }}-
+          
+      - name: Publish Local
+        run: (cd CMT && exec sbt publishLocal)
+
+      - name: Setup Coursier
+        run: |
+          curl -fLo coursier https://git.io/coursier-cli &&
+          chmod +x coursier &&
+          ./coursier
+      
+      - name: Package Binaries
+        run: |
+          mkdir -p course-management-tools/bin
+          cp CMT/bin/* course-management-tools/bin/
+          ./coursier bootstrap com.github.eloots:studentify_2.13:latest.release -o course-management-tools/bin/cmt-studentify --standalone
+          ./coursier bootstrap com.github.eloots:linearize_2.13:latest.release -o course-management-tools/bin/cmt-linearize --standalone
+          ./coursier bootstrap com.github.eloots:delinearize_2.13:latest.release -o course-management-tools/bin/cmt-delinearize --standalone
+          ./coursier bootstrap com.github.eloots:mainadm_2.13:latest.release -o course-management-tools/bin/cmt-mainadm --standalone
+          zip -r course-management-tools.zip course-management-tools
+          
+      - name: Create Github Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+          
+      - name: Upload assets to Github release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./course-management-tools.zip
+          asset_name: course-management-tools.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
- Add release action
- Use `Coursier`to generate binary launchers
- Upload generated binaries as a zip archive to release assets.

> Users downloading the artifacts should add `course-management-tools/bin` to `$PATH`