### PR TITLE
Adapt test script generation to support cmt binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
         run: |
           mkdir -p course-management-tools/bin
           cp CMT/bin/* course-management-tools/bin/
-          ./coursier bootstrap com.github.eloots:studentify_2.13:latest.release -o course-management-tools/bin/cmt-studentify --standalone
-          ./coursier bootstrap com.github.eloots:linearize_2.13:latest.release -o course-management-tools/bin/cmt-linearize --standalone
-          ./coursier bootstrap com.github.eloots:delinearize_2.13:latest.release -o course-management-tools/bin/cmt-delinearize --standalone
-          ./coursier bootstrap com.github.eloots:mainadm_2.13:latest.release -o course-management-tools/bin/cmt-mainadm --standalone
+          ./coursier bootstrap com.github.eloots:studentify_2.13:latest.release -o course-management-tools/bin/cmt-studentify --standalone --java-opt -Drun.mode=RELEASE
+          ./coursier bootstrap com.github.eloots:linearize_2.13:latest.release -o course-management-tools/bin/cmt-linearize --standalone --java-opt -Drun.mode=RELEASE
+          ./coursier bootstrap com.github.eloots:delinearize_2.13:latest.release -o course-management-tools/bin/cmt-delinearize --standalone --java-opt -Drun.mode=RELEASE
+          ./coursier bootstrap com.github.eloots:mainadm_2.13:latest.release -o course-management-tools/bin/cmt-mainadm --standalone --java-opt -Drun.mode=RELEASE
           zip -r course-management-tools.zip course-management-tools
           
       - name: Create Github Release

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,1 @@
+-Drun.mode=DEV

--- a/core/src/main/scala/com/lightbend/coursegentools/GenTests.scala
+++ b/core/src/main/scala/com/lightbend/coursegentools/GenTests.scala
@@ -18,10 +18,34 @@ object GenTests {
     val exerciseFolderPath: String =
       if (relativeSourceFolder != "") new File(mainRepo, relativeSourceFolder).getAbsolutePath else mainRepoPath
 
+    val runMode = System.getProperty("run.mode")
     val cmtFolder = System.getProperty("user.dir")
-    val configurationFileArgument = if (configurationFile.isDefined) s"-cfg ${configurationFile.get}" else ""
+    val configurationFileArgument =
+      if (configurationFile.isDefined) s"-cfg ${configurationFile.get}" else ""
     val isADottyProjectOption = if (isADottyProject) "-dot" else ""
     val initStudentifiedRepoAsGitOption = if (initStudentifiedRepoAsGit) "-g" else ""
+
+    def genLinearizeCmds: String =
+      if (runMode == "DEV")
+        s"""|${separator("Linearize the project")}
+            |cd $$CMT_FOLDER
+            |sbt "linearize $configurationFileArgument $isADottyProjectOption $mainRepoPath $$TMP_DIR_LIN
+        """".stripMargin
+      else
+        s"""|${separator("Linearize the project")}
+            |cmt-linearize $configurationFileArgument $isADottyProjectOption $mainRepoPath $$TMP_DIR_LIN
+        """.stripMargin
+
+    def genStudentifyCmds: String =
+      if (runMode == "DEV")
+        s"""|${separator("Studentify the project")}
+            |cd $$CMT_FOLDER
+            |sbt "studentify $configurationFileArgument $isADottyProjectOption $initStudentifiedRepoAsGitOption $mainRepoPath $$TMP_DIR_STU
+        """.stripMargin
+      else
+        s"""|${separator("Studentify the project")}
+            |cmt-studentify $configurationFileArgument $isADottyProjectOption $initStudentifiedRepoAsGitOption $mainRepoPath $$TMP_DIR_STU
+        """.stripMargin
 
     val script: String =
       s"""#!/bin/bash
@@ -29,7 +53,7 @@ object GenTests {
          |set -e
          |set -o pipefail
          |
-         |CMT_FOLDER=$cmtFolder # This should become a script argument at some stage
+         |${if(runMode == "DEV") s"CMT_FOLDER=$cmtFolder" else ""}
          |
          |${separator("Test main repo 'man e', 'test'")}
          |cd $exerciseFolderPath
@@ -38,18 +62,14 @@ object GenTests {
          |${separator("Create temporary folders to hold linearized and studentified versions")}
          |TMP_DIR_LIN=$$(mktemp -d /tmp/CMT.XXXXXX)
          |TMP_DIR_STU=$$(mktemp -d /tmp/CMT.XXXXXX)
-         |cd $$CMT_FOLDER
          |
-         |${separator("Linearize the project")}
-         |sbt "linearize $configurationFileArgument $isADottyProjectOption $mainRepoPath $$TMP_DIR_LIN"
+         |${genLinearizeCmds}
          |
          |${separator("Test linearized project")}
          |cd $$TMP_DIR_LIN/${mainRepo.getName}
          |sbt test
          |
-         |${separator("Studentify the project")}
-         |cd $$CMT_FOLDER
-         |sbt "studentify $configurationFileArgument $isADottyProjectOption $initStudentifiedRepoAsGitOption $mainRepoPath $$TMP_DIR_STU"
+         |${genStudentifyCmds}
          |
          |${separator("Test studentified project:\n  Exercise 'nextExercise', 'pullSolution', 'listExercises', 'man e' commands")}
          |cd $$TMP_DIR_STU/${mainRepo.getName}

--- a/core/src/main/scala/com/lightbend/coursegentools/GenTests.scala
+++ b/core/src/main/scala/com/lightbend/coursegentools/GenTests.scala
@@ -20,8 +20,7 @@ object GenTests {
 
     val runMode = System.getProperty("run.mode")
     val cmtFolder = System.getProperty("user.dir")
-    val configurationFileArgument =
-      if (configurationFile.isDefined) s"-cfg ${configurationFile.get}" else ""
+    val configurationFileArgument = if (configurationFile.isDefined) s"-cfg ${configurationFile.get}" else ""
     val isADottyProjectOption = if (isADottyProject) "-dot" else ""
     val initStudentifiedRepoAsGitOption = if (initStudentifiedRepoAsGit) "-g" else ""
 
@@ -29,8 +28,8 @@ object GenTests {
       if (runMode == "DEV")
         s"""|${separator("Linearize the project")}
             |cd $$CMT_FOLDER
-            |sbt "linearize $configurationFileArgument $isADottyProjectOption $mainRepoPath $$TMP_DIR_LIN
-        """".stripMargin
+            |sbt "linearize $configurationFileArgument $isADottyProjectOption $mainRepoPath $$TMP_DIR_LIN"
+        """.stripMargin
       else
         s"""|${separator("Linearize the project")}
             |cmt-linearize $configurationFileArgument $isADottyProjectOption $mainRepoPath $$TMP_DIR_LIN
@@ -40,7 +39,7 @@ object GenTests {
       if (runMode == "DEV")
         s"""|${separator("Studentify the project")}
             |cd $$CMT_FOLDER
-            |sbt "studentify $configurationFileArgument $isADottyProjectOption $initStudentifiedRepoAsGitOption $mainRepoPath $$TMP_DIR_STU
+            |sbt "studentify $configurationFileArgument $isADottyProjectOption $initStudentifiedRepoAsGitOption $mainRepoPath $$TMP_DIR_STU"
         """.stripMargin
       else
         s"""|${separator("Studentify the project")}


### PR DESCRIPTION
**Add support for generating test script on different environments.**

- A system property is introduced in file `.sbtopts`
- Perform script generation based on the system property.
- `Coursier bootstrap` supports adding `Java Option` to the generated artifact using option `--java-opt`
- CI pipeline is adapted to add this new option to the generated binaries