### PR TITLE
Fix studentify & linearize default branch naming to 'main'

### DIFF
--- a/core/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/core/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -233,6 +233,11 @@ object Helpers {
       .runAndExitIfFailed(toConsoleRed(s"'git rename branch' failed on ${gitProject.getAbsolutePath}"))
   }
 
+  def getStudentifiedBranchName(studentifiedRepo: File): String = {
+    val cmd = s"""git rev-parse --abbrev-ref HEAD""".toProcessCmd(workingDir = studentifiedRepo)
+    Process(cmd.cmd, cmd.workingDir).!!.trim()
+  }
+
   def commitFirstExercise(exercise: String, linearizedProject: File): Unit = {
     s"git add -A"
       .toProcessCmd(workingDir = linearizedProject)

--- a/linearize/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/linearize/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -102,7 +102,8 @@ object Linearize {
     initializeGitRepo(linearizedProject)
     commitFirstExercise(exercises.head, linearizedProject)
     commitRemainingExercises(exercises.tail, cleanMainRepo, linearizedProject)
-    renameMainBranch(linearizedProject)
+    if( Helpers.getStudentifiedBranchName(linearizedProject) != "main")
+      renameMainBranch(linearizedProject)
 
     sbtio.delete(tmpDir)
   }

--- a/studentify/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/studentify/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -89,6 +89,7 @@ object Studentify {
       .runAndExitIfFailed(
         toConsoleRed(s"'Initial commit failed on ${studentifiedRepo.getAbsolutePath}")
       )
-    Helpers.renameMainBranch(studentifiedRepo)
+    if( Helpers.getStudentifiedBranchName(studentifiedRepo) != "main")
+      Helpers.renameMainBranch(studentifiedRepo)
   }
 }


### PR DESCRIPTION
- As of git version 2.28.0, the default branch name can be set
  via `git config --global init.defaultBranch main` (setting it to
  `main`.
  This was not accounted for when running `linearize` or `studentify -g`
- This fix wil do the renaming only if the default branch name is not
  `main`