### PR TITLE
Setup CI to publish documentation to github pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,30 @@
+name: Publish Docs
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/**"
+      - "website/**"
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11 
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+
+      - name: Publish docs to Github Pages 🚀
+        env:
+          GITHUB_DEPLOY_KEY: ${{secrets.GH_DEPLOY_KEY}}
+        run: sbt "docs/docusaurusPublishGhpages"


### PR DESCRIPTION
Any new changes inside `docs` and `website` folders merged to `main` branch gets published to `github pages`.

To make this PR complete, the following changes need to be made on repository settings.

### 1. Deploy Key

Generate a fresh SSH key using `ssh-keygen`

```sh
mkdir github
cd github
ssh-keygen -t rsa -b 4096 -C "youremail@gmail.com"
Enter file in which to save the key (/Users/robinraju/.ssh/id_rsa): cmt
Enter passphrase (empty for no passphrase): <ENTER, NO PASSPHRASE>
Enter same passphrase again: <ENTER, NO PASSPHRASE>
Your identification has been saved in cmt.
Your public key has been saved in cmt.pub.
```
Copy the public key to clipboard
```sh
cat cmt.pub | pbcopy
```

Open the "Deploy key" menu in project settings: https://github.com/eloots/course-management-tools/settings/keys/new
Paste the key and `allow write access`
![Deploy key](https://i.imgur.com/F8WmNcT.png)

### 2. Github Secret

Copy the `private key` as base64 encoded (file without .pub extension )

```sh
cat cmt | base64 |pbcopy
```
Open github secrets for the repo: https://github.com/eloots/course-management-tools/settings/secrets/new

![Github Secret](https://i.imgur.com/SJAXbcO.png)
> Name of the secret should be `GH_DEPLOY_KEY ` since I have referenced it inside actions workflow.