### PR TITLE
Fix broken links in footer in reference pages

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -12,8 +12,9 @@ class Footer extends React.Component {
     const baseUrl = this.props.config.baseUrl;
     const docsUrl = this.props.config.docsUrl;
     const docsPart = `${docsUrl ? `${docsUrl}/` : ''}`;
-    const langPart = `${language ? `${language}/` : ''}`;
-    return `${baseUrl}${docsPart}${langPart}${doc}`;
+    // const langPart = `${language ? `${language}/` : ''}`;
+    // return `${baseUrl}${docsPart}${langPart}${doc}`;
+    return `${baseUrl}${docsPart}${doc}`;
   }
 
   pageUrl(doc, language) {


### PR DESCRIPTION
- Probably caused multi-language support in docusaurus that we
  don't fully understand.
- Assuming for the time being thatwe only will support docs in
  English.