### PR TITLE
Resolve main repo path based on context

### DIFF
--- a/core/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/core/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -684,4 +684,18 @@ object Helpers {
          |}
        """.stripMargin, new File(targetFolder, "project/SSettings.scala").getPath)
   }
+
+  def resolveMainRepoPath(mainRepo: File): File = {
+    if (mainRepo.getPath == ".") {
+      val repoPath = getRepoPathFromGit()
+      new File(repoPath)
+    } else {
+      mainRepo
+    }
+  }
+
+  def getRepoPathFromGit(): String = {
+    "git rev-parse --show-toplevel"
+      .toProcessCmd(workingDir = new File(".")).runAndReadOutput()
+  }
 }

--- a/core/src/main/scala/com/lightbend/coursegentools/ProcessDSL.scala
+++ b/core/src/main/scala/com/lightbend/coursegentools/ProcessDSL.scala
@@ -21,9 +21,8 @@ package com.lightbend.coursegentools
   */
 
 import java.io.File
-
 import scala.sys.process.Process
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object ProcessDSL {
   case class ProcessCmd(cmd: Seq[String], workingDir: File)
@@ -44,6 +43,20 @@ object ProcessDSL {
     def run: Int = {
       val status = Try(Process(cmd.cmd, cmd.workingDir).!)
       status.getOrElse(-1)
+    }
+
+    def runAndReadOutput(): String = {
+      val consoleRes = Try(Process(cmd.cmd, cmd.workingDir).!!)
+      consoleRes match {
+        case Success(result) => result.trim
+        case Failure(_) =>
+          println(s"""
+                   |  Executed command: ${cmd.cmd.mkString(" ")}
+                   |  Working directory: ${cmd.workingDir}
+          """.stripMargin)
+          System.exit(-1)
+          ""
+      }
     }
   }
 

--- a/delinearize/src/main/scala/com/lightbend/coursegentools/DeLinearize.scala
+++ b/delinearize/src/main/scala/com/lightbend/coursegentools/DeLinearize.scala
@@ -27,7 +27,8 @@ object DeLinearize {
 
     val cmdOptions = DeLinearizeCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val DeLinearizeCmdOptions(mainRepo, linearizedRepo, optConfigurationFile) = cmdOptions.get
+    val DeLinearizeCmdOptions(mainRepoPath, linearizedRepo, optConfigurationFile) = cmdOptions.get
+    val mainRepo = resolveMainRepoPath(mainRepoPath)
 
     implicit val config: MainSettings = new MainSettings(mainRepo, optConfigurationFile)
     implicit val eofe: ExitOnFirstError = ExitOnFirstError(true)

--- a/linearize/src/main/scala/com/lightbend/coursegentools/Linearize.scala
+++ b/linearize/src/main/scala/com/lightbend/coursegentools/Linearize.scala
@@ -33,7 +33,7 @@ object Linearize {
 
     val cmdOptions = LinearizeCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val LinearizeCmdOptions(mainRepo,
+    val LinearizeCmdOptions(mainRepoPath,
                             linearizedOutputFolder,
                             multiJVM,
                             forceDeleteExistingDestinationFolder,
@@ -42,6 +42,7 @@ object Linearize {
                             autoReloadOnBuildDefChange,
                             bareLinRepo) = cmdOptions.get
 
+    val mainRepo = resolveMainRepoPath(mainRepoPath)
     implicit val config: MainSettings = new MainSettings(mainRepo, configurationFile)
 
     exitIfGitIndexOrWorkspaceIsntClean(mainRepo)

--- a/mainadm/src/main/scala/com/lightbend/coursegentools/MainAdm.scala
+++ b/mainadm/src/main/scala/com/lightbend/coursegentools/MainAdm.scala
@@ -12,7 +12,7 @@ object MainAdm {
 
     val cmdOptions = MainAdmCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val MainAdmCmdOptions(mainRepo,
+    val MainAdmCmdOptions(mainRepoPath,
                           multiJVM,
                           regenBuildFile,
                           duplicateInsertBefore,
@@ -31,6 +31,7 @@ object MainAdm {
                           initCmdOptions
     ) = cmdOptions.get
 
+    val mainRepo = resolveMainRepoPath(mainRepoPath)
     implicit val exitOnFirstError: ExitOnFirstError = ExitOnFirstError(true)
     implicit val config: MainSettings = new MainSettings(mainRepo, configurationFile)
 

--- a/studentify/src/main/scala/com/lightbend/coursegentools/Studentify.scala
+++ b/studentify/src/main/scala/com/lightbend/coursegentools/Studentify.scala
@@ -13,7 +13,7 @@ object Studentify {
 
     val cmdOptions = StudentifyCmdLineOptParse.parse(args)
     if (cmdOptions.isEmpty) System.exit(-1)
-    val StudentifyCmdOptions(mainRepo,
+    val StudentifyCmdOptions(mainRepoPath,
                              targetFolder,
                              multiJVM,
                              firstOpt,
@@ -26,6 +26,7 @@ object Studentify {
                              autoReloadOnBuildDefChange
     ) = cmdOptions.get
 
+    val mainRepo = resolveMainRepoPath(mainRepoPath)
     implicit val config: MainSettings = new MainSettings(mainRepo, configurationFile)
 
     exitIfGitIndexOrWorkspaceIsntClean(mainRepo)


### PR DESCRIPTION
This PR tries to fix an error resolving the main repo path relative to the current directory. 

Before:
`Executing CMT commands from a course  repo`
```sh
cmt-mainadm -t test.sh .
ERROR: No exercises found in .
```
```sh
cmt-linearize -dot . ../lin
CHECKING WORKSPACE in .

Destination folder ../lin/. exists: Either remove this folder
manually or use the '-f' command-line option to delete it automatically
```
```sh
cmt-studentify -dot . ../stu
CHECKING WORKSPACE in .
Initialized empty Git repository in /private/var/folders/50/tgcdyndd6h37trb0dpk5yjrc0000gn/T/sbt_889bd37f/..git/
To /var/folders/50/tgcdyndd6h37trb0dpk5yjrc0000gn/T/sbt_889bd37f/..git
 * [new branch]      HEAD -> A7ECFDFA-A8E0-471F-9970-F68F6636AE35
fatal: destination path '.' already exists and is not an empty directory.
ERROR: No exercises found in .
```