### PR TITLE
Create 'project' dir in studentified repo before adding commands

### DIFF
--- a/core/src/main/scala/com/lightbend/coursegentools/Helpers.scala
+++ b/core/src/main/scala/com/lightbend/coursegentools/Helpers.scala
@@ -352,6 +352,7 @@ object Helpers {
 
   def addSbtCommands(templateFileList: List[String], targetCourseFolder: File): Unit = {
     val projectFolder = new File(targetCourseFolder, "project")
+    sbtio.createDirectory(projectFolder)
     for {
       templateFile <- templateFileList
       template = Source.fromInputStream(this.getClass().getClassLoader().getResourceAsStream(templateFile + ".template"))


### PR DESCRIPTION
Fix for a 'NoSuchFileException' on `cmt-studentify`.

Reproduce:

- Create a new master repo of type 'scala-cmt-template-no-common'
- Don't change anything; but try to studentify it
- Observe an error like:

```
Setting student repository bookmark to step_000_initial_state
Exception in thread "main" java.nio.file.NoSuchFileException: /Users/eamelink/tmp/concurreny-on-the-jvm/project/Man.scala
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
```

The cause was that the `project` directory is not yet created in the studentified repo when `addSbtCommands` is invoked, which tries to put files in that directory.