### PR TITLE
Fix missing .gitignore file when linearizing

### DIFF
--- a/cmta/src/main/scala/cmt/admin/command/execution/Linearize.scala
+++ b/cmta/src/main/scala/cmt/admin/command/execution/Linearize.scala
@@ -62,6 +62,10 @@ private object LinearizeHelpers:
       exercises: Seq[String],
       linearizedRootFolder: File,
       cmd: Linearize): Either[String, Unit] =
+
+    val dotIgnoreFile = cleanedMainRepo / ".gitignore"
+    if dotIgnoreFile.exists then sbtio.copyFile(dotIgnoreFile, linearizedRootFolder / ".gitignore")
+
     exercises match
       case exercise +: remainingExercises =>
         val from = cleanedMainRepo / cmd.config.mainRepoExerciseFolder / exercise


### PR DESCRIPTION
The `.gitignore` file (if present) wasn't added to the linearized
repo which:

- makes the linearized repo larger than needed
- is annoying when compiling/testing code during an interactive rebasing exercise