### PR TITLE
Move all CMT related files & folders to a dedicated folder

### DIFF
--- a/cmta/src/main/scala/cmt/admin/command/execution/Studentify.scala
+++ b/cmta/src/main/scala/cmt/admin/command/execution/Studentify.scala
@@ -84,7 +84,7 @@ private object StudentifyHelpers:
     hideExercises(cleanedMainRepo, solutionsFolder, exercises)(cmd.config)
 
     writeStudentifiedCMTConfig(studentifiedRootFolder / cmd.config.cmtStudentifiedConfigFile, exercises)(cmd.config)
-    writeStudentifiedCMTBookmark(studentifiedRootFolder / ".bookmark", exercises.head)
+    writeStudentifiedCMTBookmark(studentifiedRootFolder / cmd.config.studentifiedRepoBookmarkFile, exercises.head)
 
     val successMessage = exercises.mkString("Processed exercises:\n  ", "\n  ", "\n")
     if cmd.initializeAsGitRepo.value then

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2,13 +2,6 @@ cmt {
   # Folder in the main git repository holding the exercises
   main-repo-exercise-folder = code
 
-  # Folder in studentified repo holding the exercise solutions as zip archives
-  studentified-repo-solutions-folder = .cue
-
-  # Folder in which saved exercise state will be stored
-  # This folder will be located in the `studentified-repo-solutions-folder` folder
-  studentified-saved-states-folder = .savedStates
-
   # Folder in studentified repo holding the current exercise code
   studentified-repo-active-exercise-folder = code
 
@@ -29,10 +22,6 @@ cmt {
   read-me-files = [
     "README.md"
   ]
-
-  # Name of the config file that is generated when studentifying a
-  # main git repository
-  cmt-studentified-config-file = .cmt-config
 
   # List of files or folders to leave untouched in the studentified
   # repo.

--- a/core/src/main/scala/cmt/CMTaConfig.scala
+++ b/core/src/main/scala/cmt/CMTaConfig.scala
@@ -50,19 +50,21 @@ class CMTaConfig(mainRepo: File, configFileOpt: Option[File]):
     else
       referenceConfig
 
+  // Static settings for cmt specific folders and files
+  // CMT metadata root folder
+  val cmtMetadataRootFolder = ".cmt"
+  val studentifiedRepoSolutionsFolder = s"$cmtMetadataRootFolder/.cue"
+  val studentifiedSavedStatesFolder = s"$studentifiedRepoSolutionsFolder/.savedStates"
+  val studentifiedRepoBookmarkFile = s"$cmtMetadataRootFolder/.bookmark"
+  val cmtStudentifiedConfigFile = s"$cmtMetadataRootFolder/.cmt-config"
+
   val mainRepoExerciseFolder = config.getString("cmt.main-repo-exercise-folder")
   val testCodeFolders = config.getStringList("cmt.test-code-folders").asScala
   val readMeFiles = config.getStringList("cmt.read-me-files").asScala.toSet
-  val studentifiedRepoSolutionsFolder =
-    config.getString("cmt.studentified-repo-solutions-folder")
-  val studentifiedSavedStatesFolder =
-    config.getString("cmt.studentified-saved-states-folder")
   val studentifiedRepoActiveExerciseFolder =
     config.getString("cmt.studentified-repo-active-exercise-folder")
   val linearizedRepoActiveExerciseFolder =
     config.getString("cmt.linearized-repo-active-exercise-folder")
-  val cmtStudentifiedConfigFile =
-    config.getString("cmt.cmt-studentified-config-file")
   val cmtStudentifiedDontTouch =
     config.getStringList("cmt.cmt-studentified-dont-touch").asScala
 

--- a/core/src/main/scala/cmt/CMTcConfig.scala
+++ b/core/src/main/scala/cmt/CMTcConfig.scala
@@ -23,12 +23,12 @@ import java.nio.charset.StandardCharsets
 class CMTcConfig(studentifiedRepo: File):
   import Helpers.adaptToOSSeparatorChar
 
-  val bookmarkFile: File = studentifiedRepo / ".bookmark"
-
-  private val cmtConfigFile = studentifiedRepo / ".cmt-config"
+  private val cmtConfigFile = studentifiedRepo / ".cmt/.cmt-config"
   if !cmtConfigFile.exists then printErrorAndExit("missing CMT configuration file")
 
   val cmtSettings: Config = ConfigFactory.parseFile(cmtConfigFile)
+
+  val bookmarkFile: File = studentifiedRepo / cmtSettings.getString("studentified-repo-bookmark-file")
 
   val exercises: collection.mutable.Seq[String] = cmtSettings.getStringList("exercises").asScala
 

--- a/core/src/main/scala/cmt/Helpers.scala
+++ b/core/src/main/scala/cmt/Helpers.scala
@@ -164,6 +164,7 @@ object Helpers:
     val configMap = Map(
       "studentified-repo-solutions-folder" -> config.studentifiedRepoSolutionsFolder,
       "studentified-saved-states-folder" -> config.studentifiedSavedStatesFolder,
+      "studentified-repo-bookmark-file" -> config.studentifiedRepoBookmarkFile,
       "active-exercise-folder" -> config.studentifiedRepoActiveExerciseFolder,
       "test-code-folders" -> config.testCodeFolders.asJava,
       "read-me-files" -> config.readMeFiles.asJava,


### PR DESCRIPTION
A studentified repo contains a number of (hidden) metadata folders
and files that were located either in the root folder of the
repo or in the `.cue` folder

To reduce the clutter (and to avoid distraction for the user of the
repo), all these folders and files have now been moved to a single
`.cmt` folder in the root of the repo.

This is the list of moved files and folders:

- `.bookmark`     => `.cmt/.bookmark`
- `.cmt-config`   => `.cmt/.cmt-config`
- `.cue`          => `.cmt/.cue`
- `.savedStates`  => `.cmt/.savedStates`