### PR TITLE
Adapt 'fileList' to cover a corner case

### DIFF
--- a/core/src/main/scala/cmt/Helpers.scala
+++ b/core/src/main/scala/cmt/Helpers.scala
@@ -33,9 +33,12 @@ object Helpers:
         case (rem, result) if rem.isEmpty => filesSoFar ++ result
         case (rem, tally)                 => fileList(filesSoFar ++ tally, rem)
 
-    val (seedFolders, seedFiles) =
-      sbtio.listFiles(base).partition(_.isDirectory)
-    fileList(seedFiles.toVector, seedFolders.toVector)
+    if base.isFile then
+      Vector(base)
+    else
+      val (seedFolders, seedFiles) =
+        sbtio.listFiles(base).partition(_.isDirectory)
+      fileList(seedFiles.toVector, seedFolders.toVector)
   end fileList
 
   def resolveMainRepoPath(mainRepo: File): Either[String, File] = {

--- a/core/src/main/scala/cmt/Helpers.scala
+++ b/core/src/main/scala/cmt/Helpers.scala
@@ -33,8 +33,7 @@ object Helpers:
         case (rem, result) if rem.isEmpty => filesSoFar ++ result
         case (rem, tally)                 => fileList(filesSoFar ++ tally, rem)
 
-    if base.isFile then
-      Vector(base)
+    if base.isFile then Vector(base)
     else
       val (seedFolders, seedFiles) =
         sbtio.listFiles(base).partition(_.isDirectory)


### PR DESCRIPTION
- When passing a `File` to `fileList`, the latter now return
  a collection holding the `File` if it corresponds to an existing
  file. Before this change, an empty Vector would be returned.