### PR TITLE
Fix goto exercise and goto first exercise

### DIFF
--- a/cmtc/src/main/scala/cmt/client/command/execution/GotoExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/GotoExercise.scala
@@ -22,11 +22,17 @@ import cmt.{toConsoleGreen, toConsoleYellow}
 given Executable[GotoExercise] with
   extension (cmd: GotoExercise)
     def execute(): Either[String, String] = {
-      if !cmd.config.exercises.contains(cmd.exerciseId.value)
-      then Left(s"No such exercise: ${cmd.exerciseId.value}")
-      else
-        withZipFile(cmd.config.solutionsFolder, cmd.exerciseId.value) { solution =>
-          copyTestCodeAndReadMeFiles(solution, cmd.exerciseId.value)(cmd.config)
-          Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(s"${cmd.exerciseId.value}")}")
-        }
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
+      val GotoExerciseId = cmd.exerciseId.value
+      val gotoExerciseIdExists = cmd.config.exercises.contains(GotoExerciseId)
+
+      (gotoExerciseIdExists, currentExerciseId) match {
+        case (false, _)             => Left(toConsoleGreen(s"No such exercise: ${cmd.exerciseId.value}"))
+        case (true, GotoExerciseId) => Left(toConsoleGreen(s"You're already at exercise ${GotoExerciseId}"))
+        case _ =>
+          withZipFile(cmd.config.solutionsFolder, cmd.exerciseId.value) { solution =>
+            copyTestCodeAndReadMeFiles(solution, cmd.exerciseId.value)(cmd.config)
+            Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(s"${cmd.exerciseId.value}")}")
+          }
+      }
     }

--- a/cmtc/src/main/scala/cmt/client/command/execution/ListExercises.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/ListExercises.scala
@@ -23,11 +23,11 @@ import java.nio.charset.StandardCharsets
 given Executable[ListExercises] with
   extension (cmd: ListExercises)
     def execute(): Either[String, String] = {
-      val currentExercise =
-        sbtio.readLines(cmd.config.bookmarkFile, StandardCharsets.UTF_8).head
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
+
       val messages = cmd.config.exercises.zipWithIndex
         .map { case (exName, index) =>
-          toConsoleGreen(f"${index + 1}%3d. ${starCurrentExercise(currentExercise, exName)}  $exName")
+          toConsoleGreen(f"${index + 1}%3d. ${starCurrentExercise(currentExerciseId, exName)}  $exName")
         }
         .mkString("\n")
       Right(messages)

--- a/cmtc/src/main/scala/cmt/client/command/execution/NextExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/NextExercise.scala
@@ -24,15 +24,16 @@ import java.nio.charset.StandardCharsets
 given Executable[NextExercise] with
   extension (cmd: NextExercise)
     def execute(): Either[String, String] = {
-      val currentExercise =
-        sbtio.readLines(cmd.config.bookmarkFile, StandardCharsets.UTF_8).head
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
+      val LastExerciseId = cmd.config.exercises.last
 
-      if currentExercise == cmd.config.exercises.last
-      then Left(toConsoleGreen(s"You're already at the last exercise: $currentExercise"))
-      else
-        withZipFile(cmd.config.solutionsFolder, cmd.config.nextExercise(currentExercise)) { solution =>
-          copyTestCodeAndReadMeFiles(solution, cmd.config.nextExercise(currentExercise))(cmd.config)
-          Right(
-            s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(s"${cmd.config.nextExercise(currentExercise)}")}")
-        }
+      currentExerciseId match {
+        case LastExerciseId => Left(toConsoleGreen(s"You're already at the last exercise: $currentExerciseId"))
+        case _ =>
+          withZipFile(cmd.config.solutionsFolder, cmd.config.nextExercise(currentExerciseId)) { solution =>
+            copyTestCodeAndReadMeFiles(solution, cmd.config.nextExercise(currentExerciseId))(cmd.config)
+            Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(
+                s"${cmd.config.nextExercise(currentExerciseId)}")}")
+          }
+      }
     }

--- a/cmtc/src/main/scala/cmt/client/command/execution/PreviousExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/PreviousExercise.scala
@@ -24,15 +24,16 @@ import java.nio.charset.StandardCharsets
 given Executable[PreviousExercise] with
   extension (cmd: PreviousExercise)
     def execute(): Either[String, String] = {
-      val currentExercise =
-        sbtio.readLines(cmd.config.bookmarkFile, StandardCharsets.UTF_8).head
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
+      val FistExerciseId = cmd.config.exercises.head
 
-      if currentExercise == cmd.config.exercises.head
-      then Left(toConsoleGreen(s"You're already at the first exercise: $currentExercise"))
-      else
-        withZipFile(cmd.config.solutionsFolder, cmd.config.previousExercise(currentExercise)) { solution =>
-          copyTestCodeAndReadMeFiles(solution, cmd.config.previousExercise(currentExercise))(cmd.config)
-          Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(
-              s"${cmd.config.previousExercise(currentExercise)}")}")
-        }
+      currentExerciseId match {
+        case FistExerciseId => Left(toConsoleGreen(s"You're already at the first exercise: $currentExerciseId"))
+        case _ =>
+          withZipFile(cmd.config.solutionsFolder, cmd.config.previousExercise(currentExerciseId)) { solution =>
+            copyTestCodeAndReadMeFiles(solution, cmd.config.previousExercise(currentExerciseId))(cmd.config)
+            Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(
+                s"${cmd.config.previousExercise(currentExerciseId)}")}")
+          }
+      }
     }

--- a/cmtc/src/main/scala/cmt/client/command/execution/PullSolution.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/PullSolution.scala
@@ -27,17 +27,16 @@ import sbt.io.syntax.singleFileFinder
 given Executable[PullSolution] with
   extension (cmd: PullSolution)
     def execute(): Either[String, String] = {
-      val currentExercise =
-        sbtio.readLines(cmd.config.bookmarkFile, StandardCharsets.UTF_8).head
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
 
       deleteCurrentState(cmd.studentifiedRepo.value)(cmd.config)
 
-      withZipFile(cmd.config.solutionsFolder, currentExercise) { solution =>
-        val files = fileList(solution / currentExercise)
+      withZipFile(cmd.config.solutionsFolder, currentExerciseId) { solution =>
+        val files = fileList(solution / currentExerciseId)
         sbtio.copyDirectory(
-          cmd.config.solutionsFolder / currentExercise,
+          cmd.config.solutionsFolder / currentExerciseId,
           cmd.config.activeExerciseFolder,
           preserveLastModified = true)
-        Right(toConsoleGreen(s"Pulled solution for $currentExercise"))
+        Right(toConsoleGreen(s"Pulled solution for $currentExerciseId"))
       }
     }

--- a/cmtc/src/main/scala/cmt/client/command/execution/PullTemplate.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/PullTemplate.scala
@@ -27,10 +27,9 @@ import java.nio.charset.StandardCharsets
 given Executable[PullTemplate] with
   extension (cmd: PullTemplate)
     def execute(): Either[String, String] = {
-      val currentExercise =
-        sbtio.readLines(cmd.config.bookmarkFile, StandardCharsets.UTF_8).head
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
 
-      withZipFile(cmd.config.solutionsFolder, currentExercise) { solution =>
+      withZipFile(cmd.config.solutionsFolder, currentExerciseId) { solution =>
         val fullTemplatePath = solution / cmd.templatePath.value
         (fullTemplatePath.exists, fullTemplatePath.isDirectory) match
           case (false, _) =>

--- a/cmtc/src/main/scala/cmt/client/command/execution/SaveState.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/SaveState.scala
@@ -26,22 +26,25 @@ import java.nio.charset.StandardCharsets
 given Executable[SaveState] with
   extension (cmd: SaveState)
     def execute(): Either[String, String] = {
-      val currentExercise =
-        sbtio.readLines(cmd.config.bookmarkFile, StandardCharsets.UTF_8).head
+      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
       val savedStatesFolder = cmd.config.studentifiedSavedStatesFolder
-      sbtio.delete(savedStatesFolder / currentExercise)
+
+      sbtio.delete(savedStatesFolder / currentExerciseId)
       val filesInScope = getCurrentExerciseState(cmd.studentifiedRepo.value)(cmd.config)
 
       for {
         file <- filesInScope
         f <- file.relativeTo(cmd.config.activeExerciseFolder)
-        dest = savedStatesFolder / currentExercise / f.getPath
+        dest = savedStatesFolder / currentExerciseId / f.getPath
       } {
         sbtio.touch(dest)
         sbtio.copyFile(file, dest)
       }
 
-      zipAndDeleteOriginal(baseFolder = savedStatesFolder, zipToFolder = savedStatesFolder, exercise = currentExercise)
+      zipAndDeleteOriginal(
+        baseFolder = savedStatesFolder,
+        zipToFolder = savedStatesFolder,
+        exercise = currentExerciseId)
 
-      Right(toConsoleGreen(s"Saved state for $currentExercise"))
+      Right(toConsoleGreen(s"Saved state for $currentExerciseId"))
     }

--- a/cmtc/src/main/scala/cmt/client/command/execution/package.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/package.scala
@@ -19,6 +19,8 @@ import sbt.io.syntax.File
 import sbt.io.IO as sbtio
 import sbt.io.syntax.fileToRichFile
 
+import java.nio.charset.StandardCharsets
+
 package object execution {
 
   private final case class PathARO(absolutePath: File, maybeRelativePath: Option[File])
@@ -40,6 +42,9 @@ package object execution {
   def deleteCurrentState(studentifiedRepo: File)(config: CMTcConfig): Unit =
     val filesToBeDeleted: Seq[File] = getCurrentExerciseState(studentifiedRepo)(config)
     sbtio.deleteFilesEmptyDirs(filesToBeDeleted)
+
+  def getCurrentExerciseId(bookmarkFile: File): String =
+    sbtio.readLines(bookmarkFile, StandardCharsets.UTF_8).head
 
   def copyTestCodeAndReadMeFiles(solution: File, prevOrNextExercise: String)(config: CMTcConfig): Unit =
 


### PR DESCRIPTION
- Fixes #184
- `cmtc goto-exercise`: Add missing check if current exercise is the one specified to go to
- factor out code to get current exercise ID
- Minor refactoring of code for better readbility