### PR TITLE
Swap out brute force test code pulling

### DIFF
--- a/cmta/src/main/scala/cmt/admin/command/execution/Studentify.scala
+++ b/cmta/src/main/scala/cmt/admin/command/execution/Studentify.scala
@@ -17,6 +17,7 @@ import cmt.Helpers.*
 import cmt.admin.command.AdminCommand.Studentify
 import cmt.core.execution.Executable
 import cmt.{Helpers, StudentifiedSkelFolders, toConsoleGreen}
+import com.typesafe.config.{ConfigFactory, ConfigRenderOptions}
 import sbt.io.IO as sbtio
 import sbt.io.syntax.*
 
@@ -79,7 +80,10 @@ private object StudentifyHelpers:
       solutionsFolder: File,
       cmd: Studentify,
       tmpFolder: File): Either[String, String] =
+
     addFirstExercise(cleanedMainRepo, exercises.head, studentifiedRootFolder)(cmd.config)
+
+    writeTestReadmeCodeMetadata(cleanedMainRepo, exercises, studentifiedRootFolder, cmd.config)
 
     hideExercises(cleanedMainRepo, solutionsFolder, exercises)(cmd.config)
 

--- a/cmtc/src/main/scala/cmt/client/command/execution/NextExercise.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/NextExercise.scala
@@ -13,27 +13,84 @@ package cmt.client.command.execution
   * See the License for the specific language governing permissions and limitations under the License.
   */
 
-import cmt.Helpers.withZipFile
+import cmt.Helpers.{deleteFileIfExists, fileSize, fileSha256Hex, withZipFile, writeStudentifiedCMTBookmark}
 import cmt.client.command.ClientCommand.NextExercise
 import cmt.core.execution.Executable
 import cmt.{toConsoleGreen, toConsoleYellow}
 import sbt.io.IO as sbtio
+import sbt.io.syntax
+import sbt.io.syntax.fileToRichFile
+import com.typesafe.config.{Config, ConfigFactory, ConfigObject, ConfigValue}
 
+//import java.io.File
+import scala.jdk.CollectionConverters.*
 import java.nio.charset.StandardCharsets
 
 given Executable[NextExercise] with
   extension (cmd: NextExercise)
     def execute(): Either[String, String] = {
-      val currentExerciseId = getCurrentExerciseId(cmd.config.bookmarkFile)
-      val LastExerciseId = cmd.config.exercises.last
+      val cMTcConfig = cmd.config
+      val currentExerciseId = getCurrentExerciseId(cMTcConfig.bookmarkFile)
+      val LastExerciseId = cMTcConfig.exercises.last
+
+//      cmd.config.readmeFilesMetaData.foreach { case (k, v) => println(s"$k ->\n${v.mkString("    ", "\n    ", "\n")}")}
 
       currentExerciseId match {
         case LastExerciseId => Left(toConsoleGreen(s"You're already at the last exercise: $currentExerciseId"))
         case _ =>
-          withZipFile(cmd.config.solutionsFolder, cmd.config.nextExercise(currentExerciseId)) { solution =>
-            copyTestCodeAndReadMeFiles(solution, cmd.config.nextExercise(currentExerciseId))(cmd.config)
-            Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(
-                s"${cmd.config.nextExercise(currentExerciseId)}")}")
+          val activeExerciseFolder = cMTcConfig.activeExerciseFolder
+          val nextExercise = cMTcConfig.nextExercise(currentExerciseId)
+          val currentReadmeFiles = cMTcConfig.readmeFilesMetaData(currentExerciseId).keys.to(Set)
+          val nextReadmeFiles = cMTcConfig.readmeFilesMetaData(nextExercise).keys.to(Set)
+          val currentTestCodeFiles = cMTcConfig.testCodeMetaData(currentExerciseId).keys.to(Set)
+          val nextTestCodeFiles = cMTcConfig.testCodeMetaData(nextExercise).keys.to(Set)
+
+          val readmefilesToBeDeleted = currentReadmeFiles &~ nextReadmeFiles
+          val readmeFilesToBeCopied = nextReadmeFiles &~ readmefilesToBeDeleted
+          val testCodeFilesToBeDeleted = currentTestCodeFiles &~ nextTestCodeFiles
+          val testCodeFilesToBeCopied = nextTestCodeFiles &~ testCodeFilesToBeDeleted
+
+          val (existingTestCodeFiles, deletedTestCodeFiles) =
+            currentTestCodeFiles.partition(file => (activeExerciseFolder / file).exists())
+
+          val modifiedTestCodeFiles = existingTestCodeFiles.foldLeft(List.empty[String]) { case (acc, file) =>
+            if (
+              (activeExerciseFolder / file).exists() &&
+              (fileSize(activeExerciseFolder / file) !=
+                cMTcConfig.testCodeMetaData(currentExerciseId)(file).size ||
+                fileSha256Hex(activeExerciseFolder / file) !=
+                cMTcConfig.testCodeMetaData(currentExerciseId)(file).sha256)
+            )
+              file +: acc
+            else
+              acc
           }
+
+          if (!modifiedTestCodeFiles.isEmpty)
+            Left(s"""next-exercise cancelled.
+                 |You have modified the following file(s):
+                 |${modifiedTestCodeFiles.mkString("\n   ", "\n   ", "\n")}
+
+                    |""".stripMargin)
+          else
+            withZipFile(cmd.config.solutionsFolder, nextExercise) { solution =>
+              for {
+                file <- readmefilesToBeDeleted
+              } deleteFileIfExists(activeExerciseFolder / file)
+              for {
+                file <- readmeFilesToBeCopied
+              } sbtio.copyFile(solution / file, activeExerciseFolder / file)
+              for {
+                file <- testCodeFilesToBeDeleted
+              } deleteFileIfExists(activeExerciseFolder / file)
+              for {
+                file <- testCodeFilesToBeCopied
+              } sbtio.copyFile(solution / file, activeExerciseFolder / file)
+
+              writeStudentifiedCMTBookmark(cMTcConfig.bookmarkFile, nextExercise)
+
+              Right(s"${toConsoleGreen("Moved to ")} " + "" + s"${toConsoleYellow(
+                  s"${cmd.config.nextExercise(currentExerciseId)}")}")
+            }
       }
     }

--- a/cmtc/src/main/scala/cmt/client/command/execution/package.scala
+++ b/cmtc/src/main/scala/cmt/client/command/execution/package.scala
@@ -56,12 +56,7 @@ package object execution {
     } sbtio.delete(config.activeExerciseFolder / path)
 
     val (dirs, files) =
-      pathsToCopy
-        .filter { path =>
-          val solutionPath = solution / path
-          solution.exists()
-        }
-        .partition(path => (solution / path).isDirectory)
+      pathsToCopy.filter(path => (solution / path).exists()).partition(path => (solution / path).isDirectory)
 
     for {
       dir <- dirs

--- a/core/src/main/scala/cmt/CMTaConfig.scala
+++ b/core/src/main/scala/cmt/CMTaConfig.scala
@@ -57,6 +57,7 @@ class CMTaConfig(mainRepo: File, configFileOpt: Option[File]):
   val studentifiedSavedStatesFolder = s"$studentifiedRepoSolutionsFolder/.savedStates"
   val studentifiedRepoBookmarkFile = s"$cmtMetadataRootFolder/.bookmark"
   val cmtStudentifiedConfigFile = s"$cmtMetadataRootFolder/.cmt-config"
+  val testCodeSizeAndChecksums = s"$cmtMetadataRootFolder/.cmt-test-size-checksums"
 
   val mainRepoExerciseFolder = config.getString("cmt.main-repo-exercise-folder")
   val testCodeFolders = config.getStringList("cmt.test-code-folders").asScala

--- a/core/src/main/scala/cmt/CMTcConfig.scala
+++ b/core/src/main/scala/cmt/CMTcConfig.scala
@@ -15,7 +15,7 @@ package cmt
 
 import sbt.io.IO as sbtio
 import sbt.io.syntax.*
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigValue}
 
 import scala.jdk.CollectionConverters.*
 import java.nio.charset.StandardCharsets
@@ -44,12 +44,30 @@ class CMTcConfig(studentifiedRepo: File):
     studentifiedRepo / cmtSettings.getString("active-exercise-folder")
 
   val solutionsFolder: File = studentifiedRepo / cmtSettings.getString("studentified-repo-solutions-folder")
+
   val studentifiedSavedStatesFolder: File =
     solutionsFolder / cmtSettings.getString("studentified-saved-states-folder")
-
   val nextExercise: Map[String, String] = exercises.zip(exercises.tail).to(Map)
 
   val previousExercise: Map[String, String] =
     exercises.tail.zip(exercises).to(Map)
+
+  private val testCodeMetaDataFile = studentifiedRepo / cmtSettings.getString("test-code-size-and-checksums")
+
+  private val metadataConfig = ConfigFactory.parseFile(testCodeMetaDataFile)
+
+  val testCodeMetaData = exercises
+    .map { exercise =>
+      val x = metadataConfig.getConfig("testcode-metadata").getObjectList(exercise)
+      exercise -> exMetadata(x)
+    }
+    .to(Map)
+
+  val readmeFilesMetaData = exercises
+    .map { exercise =>
+      val x = metadataConfig.getConfig("readmefiles-metadata").getObjectList(exercise)
+      exercise -> exMetadata(x)
+    }
+    .to(Map)
 
 end CMTcConfig

--- a/core/src/main/scala/cmt/ExerciseMetadata.scala
+++ b/core/src/main/scala/cmt/ExerciseMetadata.scala
@@ -1,0 +1,19 @@
+package cmt
+
+import java.util.Map.Entry
+import scala.jdk.CollectionConverters.*
+import com.typesafe.config.{ConfigValue, ConfigFactory, ConfigObject}
+final case class FileMetadata(size: Long, sha256: String)
+extension (item: Entry[String, ConfigValue])
+  def getInt(key: String): Int = ConfigFactory.parseString(item.getValue().unwrapped().toString()).getInt(key)
+  def getString(key: String): String = ConfigFactory.parseString(item.getValue().unwrapped().toString()).getString(key)
+
+def exMetadata(files: java.util.List[? <: ConfigObject]): Map[String, FileMetadata] =
+  (for {
+    item <- files.asScala
+    itemitem = item.entrySet().asScala.head
+    key = itemitem.getKey()
+    size = itemitem.getInt("size")
+    sha = itemitem.getString("sha256")
+    md = FileMetadata(size, sha)
+  } yield key -> md).to(Map)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,12 +15,13 @@ object Library {
   val scopt = "com.github.scopt" %% "scopt" % Version.scopt
   val sbtio = "org.scala-sbt" %% "io" % Version.sbtio
   val typesafeConfig = "com.typesafe" % "config" % Version.typesafeConfig
+  val commonsCodec = "commons-codec" % "commons-codec" % "1.15"
 }
 
 object Dependencies {
 
   import Library._
 
-  val cmtDependencies = List(scopt, sbtio, typesafeConfig, scalaTest, scalaCheck)
+  val cmtDependencies = List(scopt, sbtio, typesafeConfig, scalaTest, scalaCheck, commonsCodec)
 
 }


### PR DESCRIPTION
- command `next-exercise`, `previous-exercise`, `goto-exercise`, `goto-first-exercise` now only pull test code files present in the subsequent exercise, leaving any (user) test code unmodified. Also, if a student made changes to the supplied exercise code, this is detected and all test code is left as-is. This gives the student the poosibility to either force moving between exercises (using the `-f` command line option) or by saving the customised test code in a new file.

- Generate metadata for test files in config in studentified repo