### PR TITLE
Fix Scala 3 deprecation warning - wildcard type parameter issue

### DIFF
--- a/core/src/main/scala/cmt/core/cli/CliParser.scala
+++ b/core/src/main/scala/cmt/core/cli/CliParser.scala
@@ -17,7 +17,7 @@ import scopt.{OEffect, OParser}
 
 trait CliParser {
 
-  protected def _parse[T](parser: OParser[_, T], options: T)(
+  protected def _parse[T](parser: OParser[?, T], options: T)(
       args: Array[String]): Either[cmt.core.cli.CmdLineParseError, T] =
     OParser.runParser(parser, args, options) match {
       case (result, effects) => handleParsingResult(result, effects)

--- a/core/src/main/scala/cmt/core/cli/ScoptCliParser.scala
+++ b/core/src/main/scala/cmt/core/cli/ScoptCliParser.scala
@@ -29,7 +29,7 @@ final case class CmdLineParseError(errors: List[OEffect]) {
 
 object ScoptCliParser {
 
-  def parse[T](parser: OParser[_, T], options: T)(args: Array[String]): Either[CmdLineParseError, T] =
+  def parse[T](parser: OParser[?, T], options: T)(args: Array[String]): Either[CmdLineParseError, T] =
     OParser.runParser(parser, args, options) match
       case (result, effects) => handleParsingResult(result, effects)
 


### PR DESCRIPTION
- In Scala 3, the wildcard for a type parameter is `?` (instead of `_` in Scala 2)