### PR TITLE
global configuration

### DIFF
--- a/cmtc/src/main/scala/cmt/client/Configuration.scala
+++ b/cmtc/src/main/scala/cmt/client/Configuration.scala
@@ -1,83 +1,120 @@
 package cmt.client
 
+import cmt.client.Configuration.CmtHome
+import cmt.{CmtError, printErrorAndExit, printMessage, toConsoleGreen}
 import cmt.client.Domain.StudentifiedRepo
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import sbt.io.IO.write
-import sbt.io.syntax.{File, file}
+import sbt.io.syntax.*
 
-import scala.io.Source
+import scala.jdk.CollectionConverters.*
 
-final case class Configuration(coursesDirectory: CoursesDirectory, currentCourse: CurrentCourse)
+final case class Configuration(homeDirectory: CmtHome, coursesDirectory: CoursesDirectory, currentCourse: CurrentCourse)
 final case class CoursesDirectory(value: File)
-object CoursesDirectory:
-  def default(): CoursesDirectory =
-    CoursesDirectory(Configuration.CmtCourseHome)
 final case class CurrentCourse(value: StudentifiedRepo)
 
 object Configuration:
-  val UserHome = System.getProperty("user.home")
-  val CmtHome = file(s"$UserHome/.cmt")
-  val CmtGlobalConfig = file(s"$CmtHome/cmt.conf")
-  val CmtCourseHome = file(s"$UserHome/Courses")
+
+  final case class UserHome(value: File)
+  final case class CmtHome(value: File)
+  final case class CmtGlobalConfigFile(value: File) {
+    def config(): Config =
+      ConfigFactory.parseFile(value)
+  }
+  final case class CmtCoursesHome(value: File)
+
+  val UserHomeDir = System.getProperty("user.home")
+  val CmtHomeDirectoryName = ".cmt"
+  val CmtGlobalConfigName = "cmt.conf"
+  val DefaultCmtHome = s"$UserHomeDir/$CmtHomeDirectoryName"
   val CoursesDirectoryToken = "COURSES_DIRECTORY"
   val CurrentCourseToken = "CURRENT_COURSE"
   val DefaultConfigFileName = "config.default.conf"
+  val CmtHomeEnvKey = "CMT_HOME"
+
+  val DefaultCmtCoursesHome = s"$UserHomeDir/Courses"
+  val CmtCoursesHomeEnvKey = "CMT_COURSES_HOME"
+
+  private def globalConfigFile(cmtHome: CmtHome): CmtGlobalConfigFile =
+    CmtGlobalConfigFile(cmtHome.value / CmtGlobalConfigName)
 
   private val configStringTemplate =
     """
       |cmtc {
-      |
       |    courses-directory = COURSES_DIRECTORY
       |    current-course = CURRENT_COURSE
       |}
       |""".stripMargin
 
-  def load(): Configuration = {
-    createIfNotExists()
-    readFromConfigFile(CmtGlobalConfig)
+  /** loads the configuration, if the configuration is not currently available (for instance, if this is the first time
+    * `load` has run) then the default configuration is created and written to the default location. The default
+    * location is $HOME/.cmt but this can be overridden with an environment variable `CMT_HOME`.
+    *
+    * The global configuration points to a directory where all the installed courses are kept. By default this is
+    * located at `$HOME/Courses` but this can also be overridden with an environment variable `CMT_COURSE_HOME`
+    * @return
+    */
+  def load(homeDirectory: Option[File] = None): Either[CmtError, Configuration] = {
+    val cmtHomePath = homeDirectory
+      .map(home => s"$home/$CmtHomeDirectoryName")
+      .orElse(System.getenv().asScala.get(CmtHomeEnvKey))
+      .getOrElse(DefaultCmtHome)
+    val cmtHome = CmtHome(file(cmtHomePath))
+
+    val cmtCourseDirectoryPath = homeDirectory
+      .map(home => s"$home/Courses")
+      .orElse(System.getenv().asScala.get(CmtCoursesHomeEnvKey))
+      .getOrElse(DefaultCmtCoursesHome)
+    val cmtCoursesHome = CmtCoursesHome(file(cmtCourseDirectoryPath))
+
+    load(cmtHome, cmtCoursesHome)
   }
 
-  def save(configuration: Configuration): Unit = {
-    writeGlobalConfig(
-      _.replaceAll(CoursesDirectoryToken, s""""${configuration.coursesDirectory.value.getCanonicalPath}"""")
-        .replaceAll(CurrentCourseToken, s""""${configuration.currentCourse.value.value.getCanonicalPath}""""))
+  private def load(cmtHome: CmtHome, cmtCoursesHome: CmtCoursesHome): Either[CmtError, Configuration] = {
+    createIfNotExists(cmtHome, cmtCoursesHome)
+    Right(readFromConfigFile(cmtHome))
   }
 
-  private def readFromConfigFile(configFile: File): Configuration = {
-    val config = ConfigFactory.parseFile(configFile)
+  private def readFromConfigFile(cmtHome: CmtHome): Configuration = {
+    val configFile = globalConfigFile(cmtHome)
+    val config = configFile.config()
     val coursesDirectory = CoursesDirectory(file(config.getString("cmtc.courses-directory")))
-    val currentCourse = {
-      val currentCourseString = config.getString("cmtc.current-course")
-      val currentCourseFile = Option
-        .when(currentCourseString == CurrentCourseToken)(file(System.getProperty("user.dir")))
-        .getOrElse(file(currentCourseString))
-      CurrentCourse(StudentifiedRepo(currentCourseFile))
-    }
-    Configuration(coursesDirectory, currentCourse)
+    val currentCourse = CurrentCourse(StudentifiedRepo(file(config.getString("cmtc.current-course"))))
+    Configuration(cmtHome, coursesDirectory, currentCourse)
   }
 
-  private def createIfNotExists(): Unit = {
-    createCourseHomeIfNotExists()
-    createCmtHomeIfNotExists()
-    copyDefaultConfigToCmtHome()
+  private def createIfNotExists(cmtHome: CmtHome, cmtCoursesHome: CmtCoursesHome): Unit = {
+    createCourseHomeIfNotExists(cmtCoursesHome)
+    createCmtHomeIfNotExists(cmtHome)
+    createDefaultConfigIfNotExists(cmtHome, cmtCoursesHome)
   }
 
-  private def createCourseHomeIfNotExists(): Unit =
-    if (!CmtCourseHome.exists()) {
-      CmtCourseHome.mkdir()
+  private def createCourseHomeIfNotExists(cmtCoursesHome: CmtCoursesHome): Unit =
+    if (!cmtCoursesHome.value.exists()) {
+      printMessage(
+        s"the CMT_COURSES_HOME directory at '${cmtCoursesHome.value.getAbsolutePath}' does not exist, creating it")
+      cmtCoursesHome.value.mkdir()
     }
 
-  private def createCmtHomeIfNotExists(): Unit =
-    if (!CmtHome.exists()) {
-      CmtHome.mkdir()
+  private def createCmtHomeIfNotExists(cmtHome: CmtHome): Unit =
+    if (!cmtHome.value.exists()) {
+      printMessage(s"the CMT_HOME directory at '${cmtHome.value.getAbsolutePath}' does not exist, creating it")
+      cmtHome.value.mkdir()
     }
 
-  private def copyDefaultConfigToCmtHome(): Unit =
-    writeGlobalConfig(
-      _.replaceAll(CoursesDirectoryToken, s""""${CmtCourseHome.getCanonicalPath}"""")
-        .replaceAll(CurrentCourseToken, s""""${System.getProperty("user.dir")}""""))
+  private def createDefaultConfigIfNotExists(cmtHome: CmtHome, cmtCoursesHome: CmtCoursesHome): Unit = {
+    val configFile = globalConfigFile(cmtHome)
+    if (!configFile.value.exists()) {
+      printMessage(
+        s"global configuration file is missing from '${configFile.value.getAbsolutePath}' creating it with default values")
+      writeGlobalConfig(
+        configFile,
+        _.replaceAll(CoursesDirectoryToken, s""""${cmtCoursesHome.value}"""")
+          .replaceAll(CurrentCourseToken, s""""${System.getProperty("user.dir")}""""))
+    }
+  }
 
-  private def writeGlobalConfig(replaceTokens: String => String): Unit = {
+  private def writeGlobalConfig(cmtGlobalConfigFile: CmtGlobalConfigFile, replaceTokens: String => String): Unit = {
     val configStrToWrite = replaceTokens(configStringTemplate)
-    write(CmtGlobalConfig, configStrToWrite)
+    write(cmtGlobalConfigFile.value, configStrToWrite)
   }

--- a/cmtc/src/main/scala/cmt/client/Configuration.scala
+++ b/cmtc/src/main/scala/cmt/client/Configuration.scala
@@ -1,0 +1,83 @@
+package cmt.client
+
+import cmt.client.Domain.StudentifiedRepo
+import com.typesafe.config.ConfigFactory
+import sbt.io.IO.write
+import sbt.io.syntax.{File, file}
+
+import scala.io.Source
+
+final case class Configuration(coursesDirectory: CoursesDirectory, currentCourse: CurrentCourse)
+final case class CoursesDirectory(value: File)
+object CoursesDirectory:
+  def default(): CoursesDirectory =
+    CoursesDirectory(Configuration.CmtCourseHome)
+final case class CurrentCourse(value: StudentifiedRepo)
+
+object Configuration:
+  val UserHome = System.getProperty("user.home")
+  val CmtHome = file(s"$UserHome/.cmt")
+  val CmtGlobalConfig = file(s"$CmtHome/cmt.conf")
+  val CmtCourseHome = file(s"$UserHome/Courses")
+  val CoursesDirectoryToken = "COURSES_DIRECTORY"
+  val CurrentCourseToken = "CURRENT_COURSE"
+  val DefaultConfigFileName = "config.default.conf"
+
+  private val configStringTemplate =
+    """
+      |cmtc {
+      |
+      |    courses-directory = COURSES_DIRECTORY
+      |    current-course = CURRENT_COURSE
+      |}
+      |""".stripMargin
+
+  def load(): Configuration = {
+    createIfNotExists()
+    readFromConfigFile(CmtGlobalConfig)
+  }
+
+  def save(configuration: Configuration): Unit = {
+    writeGlobalConfig(
+      _.replaceAll(CoursesDirectoryToken, s""""${configuration.coursesDirectory.value.getCanonicalPath}"""")
+        .replaceAll(CurrentCourseToken, s""""${configuration.currentCourse.value.value.getCanonicalPath}""""))
+  }
+
+  private def readFromConfigFile(configFile: File): Configuration = {
+    val config = ConfigFactory.parseFile(configFile)
+    val coursesDirectory = CoursesDirectory(file(config.getString("cmtc.courses-directory")))
+    val currentCourse = {
+      val currentCourseString = config.getString("cmtc.current-course")
+      val currentCourseFile = Option
+        .when(currentCourseString == CurrentCourseToken)(file(System.getProperty("user.dir")))
+        .getOrElse(file(currentCourseString))
+      CurrentCourse(StudentifiedRepo(currentCourseFile))
+    }
+    Configuration(coursesDirectory, currentCourse)
+  }
+
+  private def createIfNotExists(): Unit = {
+    createCourseHomeIfNotExists()
+    createCmtHomeIfNotExists()
+    copyDefaultConfigToCmtHome()
+  }
+
+  private def createCourseHomeIfNotExists(): Unit =
+    if (!CmtCourseHome.exists()) {
+      CmtCourseHome.mkdir()
+    }
+
+  private def createCmtHomeIfNotExists(): Unit =
+    if (!CmtHome.exists()) {
+      CmtHome.mkdir()
+    }
+
+  private def copyDefaultConfigToCmtHome(): Unit =
+    writeGlobalConfig(
+      _.replaceAll(CoursesDirectoryToken, s""""${CmtCourseHome.getCanonicalPath}"""")
+        .replaceAll(CurrentCourseToken, s""""${System.getProperty("user.dir")}""""))
+
+  private def writeGlobalConfig(replaceTokens: String => String): Unit = {
+    val configStrToWrite = replaceTokens(configStringTemplate)
+    write(CmtGlobalConfig, configStrToWrite)
+  }

--- a/cmtc/src/test/scala/cmt/client/ConfigurationSpec.scala
+++ b/cmtc/src/test/scala/cmt/client/ConfigurationSpec.scala
@@ -2,6 +2,7 @@ package cmt.client
 
 import java.lang.reflect.Field
 import java.lang.reflect.Method
+import cmt.Helpers.adaptToOSSeparatorChar
 import cmt.client.Configuration.CmtHome
 import cmt.client.Domain.StudentifiedRepo
 import org.scalatest.BeforeAndAfterEach
@@ -29,12 +30,11 @@ final class ConfigurationSpec extends AnyWordSpecLike with Matchers with BeforeA
 
   "load" should {
     "create the default configuration in the appropriate home directory" in {
-      println(tempDirectory)
-      val userHome = file(System.getProperty("user.home"))
       val expectedConfiguration = Configuration(
         CmtHome(tempDirectory / ".cmt"),
         CoursesDirectory(tempDirectory / "Courses"),
         CurrentCourse(StudentifiedRepo(file(System.getProperty("user.dir")))))
+
       val receivedConfiguration = assertRight(Configuration.load(Some(tempDirectory)))
 
       receivedConfiguration shouldBe expectedConfiguration

--- a/cmtc/src/test/scala/cmt/client/ConfigurationSpec.scala
+++ b/cmtc/src/test/scala/cmt/client/ConfigurationSpec.scala
@@ -1,0 +1,43 @@
+package cmt.client
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import cmt.client.Configuration.CmtHome
+import cmt.client.Domain.StudentifiedRepo
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import cmt.support.EitherSupport
+import sbt.io.IO as sbtio
+import sbt.io.syntax.*
+import scala.jdk.CollectionConverters.*
+import scala.compiletime.uninitialized
+
+final class ConfigurationSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterEach with EitherSupport {
+
+  var tempDirectory: File = uninitialized
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    tempDirectory = sbtio.createTemporaryDirectory
+  }
+
+  override def afterEach(): Unit = {
+    sbtio.delete(tempDirectory)
+    super.afterEach()
+  }
+
+  "load" should {
+    "create the default configuration in the appropriate home directory" in {
+      println(tempDirectory)
+      val userHome = file(System.getProperty("user.home"))
+      val expectedConfiguration = Configuration(
+        CmtHome(tempDirectory / ".cmt"),
+        CoursesDirectory(tempDirectory / "Courses"),
+        CurrentCourse(StudentifiedRepo(file(System.getProperty("user.dir")))))
+      val receivedConfiguration = assertRight(Configuration.load(Some(tempDirectory)))
+
+      receivedConfiguration shouldBe expectedConfiguration
+    }
+  }
+}


### PR DESCRIPTION
Adds the domain objects for handling global configuration. That is, the `CMT_HOME` directory and the core `cmt` configuration that will point to the current course the student is working on in this installation and where the courses are stored in their local install.