### PR TITLE
Fix linearize bug/Improve code

### DIFF
--- a/cmta/src/main/scala/cmt/admin/command/Studentify.scala
+++ b/cmta/src/main/scala/cmt/admin/command/Studentify.scala
@@ -71,16 +71,16 @@ object Studentify:
           for {
             _ <- exitIfGitIndexOrWorkspaceIsntClean(mainRepository.value)
 
-            _ = println(s"Studentifying ${toConsoleGreen(mainRepository.value.getPath)} to ${toConsoleGreen(
-                options.studentifyBaseDirectory.value.getPath)}")
-
             mainRepoName = mainRepository.value.getName
             tmpFolder = sbtio.createTemporaryDirectory
             cleanedMainRepo = tmpFolder / mainRepoName
             studentifiedRootFolder = options.studentifyBaseDirectory.value / mainRepoName
             solutionsFolder = studentifiedRootFolder / config.studentifiedRepoSolutionsFolder
 
-            _ = checkpreExistingAndCreateArtifactRepo(
+            _ = println(
+              s"Studentifying ${toConsoleGreen(mainRepoName)} to ${toConsoleGreen(options.studentifyBaseDirectory.value.getPath)}")
+
+            _ <- checkpreExistingAndCreateArtifactRepo(
               options.studentifyBaseDirectory.value,
               studentifiedRootFolder,
               options.forceDelete.value)

--- a/core/src/main/scala/cmt/Helpers.scala
+++ b/core/src/main/scala/cmt/Helpers.scala
@@ -69,20 +69,23 @@ object Helpers:
   def checkpreExistingAndCreateArtifactRepo(
       artifactBaseDirectory: File,
       artifactRootFolder: File,
-      forceDeleteDestinationDirectory: Boolean): Unit =
+      forceDeleteDestinationDirectory: Boolean): Either[CmtError, String] =
     (artifactRootFolder.exists, forceDeleteDestinationDirectory) match
       case (true, true) =>
         if artifactBaseDirectory.canWrite then
           sbtio.delete(artifactRootFolder)
           sbtio.createDirectory(artifactRootFolder)
-        else printErrorAndExit(s"${artifactBaseDirectory.getPath} isn't writeable")
+          Right("Created artifact folder")
+        else Left(FailedToExecuteCommand(ErrorMessage(s"${artifactBaseDirectory.getPath} isn't writeable")))
 
       case (true, false) =>
-        printErrorAndExit(s"$artifactRootFolder exists already")
+        Left(FailedToExecuteCommand(ErrorMessage(s"$artifactRootFolder exists already")))
 
       case (false, _) =>
-        if artifactBaseDirectory.canWrite then sbtio.createDirectory(artifactRootFolder)
-        else printErrorAndExit(s"${artifactBaseDirectory.getPath} isn't writeable")
+        if artifactBaseDirectory.canWrite then
+          sbtio.createDirectory(artifactRootFolder)
+          Right("Created artifact folder")
+        else Left(FailedToExecuteCommand(ErrorMessage(s"${artifactBaseDirectory.getPath} isn't writeable")))
   end checkpreExistingAndCreateArtifactRepo
 
   def addFirstExercise(cleanedMainRepo: File, firstExercise: String, studentifiedRootFolder: File)(


### PR DESCRIPTION
- Fix the same issue in `linearize` command as in `studentify`. This issue was introduced during the change to `case-app` command line parsing.
- Change type of `checkpreExistingAndCreateArtifactRepo` from Unit to `Either[CmtError, String]`. This makes command execution error handling and reporting uniform.