### PR TITLE
Added set-current-course command

### DIFF
--- a/cmtc/src/main/scala/cmt/client/Main.scala
+++ b/cmtc/src/main/scala/cmt/client/Main.scala
@@ -24,7 +24,8 @@ import cmt.client.command.{
   PullSolution,
   PullTemplate,
   RestoreState,
-  SaveState
+  SaveState,
+  SetCurrentCourse
 }
 
 object Main extends CommandsEntryPoint:
@@ -40,4 +41,5 @@ object Main extends CommandsEntryPoint:
       PullSolution.command,
       PullTemplate.command,
       RestoreState.command,
-      SaveState.command)
+      SaveState.command,
+      SetCurrentCourse.command)

--- a/cmtc/src/main/scala/cmt/client/cli/CmtcCommand.scala
+++ b/cmtc/src/main/scala/cmt/client/cli/CmtcCommand.scala
@@ -1,0 +1,16 @@
+package cmt.client.cli
+
+import caseapp.core.help.Help
+import caseapp.core.parser.Parser
+import cmt.printErrorAndExit
+import cmt.client.Configuration
+import cmt.core.cli.CmtCommand
+import cats.syntax.either.*
+
+abstract class CmtcCommand[T](implicit parser: Parser[T], help: Help[T]) extends CmtCommand[T] {
+
+  protected val configuration = Configuration
+    .load()
+    .leftMap(error => printErrorAndExit(error.prettyPrint))
+    .getOrElse(printErrorAndExit("failed to load configuration"))
+}

--- a/cmtc/src/main/scala/cmt/client/command/Executable.scala
+++ b/cmtc/src/main/scala/cmt/client/command/Executable.scala
@@ -1,0 +1,7 @@
+package cmt.client.command
+
+import cmt.CmtError
+import cmt.client.Configuration
+
+trait Executable[T]:
+  extension (t: T) def execute(configuration: Configuration): Either[CmtError, String]

--- a/cmtc/src/main/scala/cmt/client/command/SetCurrentCourse.scala
+++ b/cmtc/src/main/scala/cmt/client/command/SetCurrentCourse.scala
@@ -19,7 +19,7 @@ object SetCurrentCourse:
   @CommandName("set-current-course")
   @HelpMessage("Sets the current course to point to a directory")
   final case class Options(
-      @ExtraName("d")
+      @ExtraName("s")
       directory: StudentifiedRepo)
 
   given Validatable[SetCurrentCourse.Options] with

--- a/cmtc/src/main/scala/cmt/client/command/SetCurrentCourse.scala
+++ b/cmtc/src/main/scala/cmt/client/command/SetCurrentCourse.scala
@@ -1,0 +1,49 @@
+package cmt.client.command
+
+import caseapp.{AppName, CommandName, ExtraName, HelpMessage, Recurse, RemainingArgs}
+import cmt.{CMTcConfig, CmtError, printResult, toConsoleGreen, toConsoleYellow, toExecuteCommandErrorMessage}
+import cmt.Helpers.{exerciseFileHasBeenModified, getFilesToCopyAndDelete, pullTestCode}
+import cmt.client.{Configuration, CurrentCourse}
+import cmt.client.Domain.{ExerciseId, ForceMoveToExercise, StudentifiedRepo}
+import cmt.client.cli.SharedOptions
+import cmt.client.cli.CmtcCommand
+import cmt.client.command.Executable
+import cmt.core.validation.Validatable
+import cmt.core.cli.enforceNoTrailingArguments
+import sbt.io.syntax.*
+import cmt.client.cli.ArgParsers.studentifiedRepoArgParser
+
+object SetCurrentCourse:
+
+  @AppName("set-current-course")
+  @CommandName("set-current-course")
+  @HelpMessage("Sets the current course to point to a directory")
+  final case class Options(
+      @ExtraName("d")
+      directory: StudentifiedRepo)
+
+  given Validatable[SetCurrentCourse.Options] with
+    extension (options: SetCurrentCourse.Options)
+      def validated(): Either[CmtError, SetCurrentCourse.Options] =
+        Right(options)
+      end validated
+  end given
+
+  given Executable[SetCurrentCourse.Options] with
+    extension (options: SetCurrentCourse.Options)
+      def execute(configuration: Configuration): Either[CmtError, String] =
+        configuration
+          .copy(currentCourse = CurrentCourse(options.directory))
+          .flush()
+          .map(_ => s"Current course set to '${options.directory.value.getAbsolutePath}'")
+
+  val command = new CmtcCommand[SetCurrentCourse.Options] {
+
+    def run(options: SetCurrentCourse.Options, args: RemainingArgs): Unit =
+      args
+        .enforceNoTrailingArguments()
+        .flatMap(_ => options.validated().flatMap(_.execute(configuration)))
+        .printResult()
+  }
+
+end SetCurrentCourse

--- a/cmtc/src/test/scala/cmt/client/command/SetCurrentCourseSpec.scala
+++ b/cmtc/src/test/scala/cmt/client/command/SetCurrentCourseSpec.scala
@@ -1,0 +1,54 @@
+package cmt.client.command
+
+import cmt.client.Configuration.CmtHome
+import cmt.client.Domain.StudentifiedRepo
+import cmt.client.{Configuration, CoursesDirectory, CurrentCourse}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import cmt.support.EitherSupport
+import sbt.io.IO as sbtio
+import sbt.io.syntax.*
+
+import scala.compiletime.uninitialized
+
+final class SetCurrentCourseSpec extends AnyWordSpecLike with Matchers with BeforeAndAfterEach with EitherSupport {
+
+  var tempDirectory: File = uninitialized
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    tempDirectory = sbtio.createTemporaryDirectory
+  }
+
+  override def afterEach(): Unit = {
+    sbtio.delete(tempDirectory)
+    super.afterEach()
+  }
+
+  "set-current-course" when {
+
+    "given a studentified directory" should {
+
+      "write the global configuration with the updated `current-course` value" in {
+        val expectedConfiguration = Configuration(
+          CmtHome(tempDirectory / ".cmt"),
+          CoursesDirectory(tempDirectory / "Courses"),
+          CurrentCourse(StudentifiedRepo(file(System.getProperty("user.dir")))))
+
+        val receivedConfiguration = assertRight(Configuration.load(Some(tempDirectory)))
+
+        val expectedDirectory = tempDirectory / "i-am-the-current-course-directory"
+        expectedDirectory.mkdir()
+
+        val expectedCurrentCourse = CurrentCourse(StudentifiedRepo(expectedDirectory))
+
+        SetCurrentCourse.Options(directory = expectedCurrentCourse.value).execute(receivedConfiguration)
+
+        val reloadedConfiguration: Configuration = assertRight(Configuration.load(Some(tempDirectory)))
+
+        reloadedConfiguration.currentCourse shouldBe expectedCurrentCourse
+      }
+    }
+  }
+}

--- a/core/src/main/scala/cmt/Error.scala
+++ b/core/src/main/scala/cmt/Error.scala
@@ -6,6 +6,11 @@ sealed trait CmtError {
   def prettyPrint: String
 }
 
+final case class FailedToWriteGlobalConfiguration(cause: Throwable) extends CmtError {
+  override def prettyPrint: String =
+    s"${toConsoleRed("ERROR -")} ${toConsoleCyan(s"Failed to write global configuration [$cause]")}"
+}
+
 final case class UnexpectedTrailingArguments(trailingArguments: List[String]) extends CmtError {
   override def prettyPrint: String =
     s"${toConsoleRed("ERROR -")} ${toConsoleCyan(s"Unexpected trailing arguments [${trailingArguments.mkString(",")}]")}"


### PR DESCRIPTION
Adds support for setting a current course.

This is the initial version of this functionality and currently it just takes the directory given in the options to the command and sets the `current-course` property of the global configuration to the absolute path of this file.