### PR TITLE
Change command success messages

### DIFF
--- a/cmtc/src/main/scala/cmt/client/command/ListSavedStates.scala
+++ b/cmtc/src/main/scala/cmt/client/command/ListSavedStates.scala
@@ -39,7 +39,10 @@ object ListSavedStates:
           .map(item => MatchDotzip.replaceAllIn(item, ""))
           .filter(config.exercises.contains(_))
 
-      Right(
+      if (savedStates.isEmpty)
+        Right(toConsoleGreen(s"No saved states found\n"))
+      else
+        Right(
         toConsoleGreen(s"Saved states available for exercises:\n") + toConsoleYellow(
           s"${savedStates.mkString("\n   ", "\n   ", "\n")}"))
     }

--- a/cmtc/src/main/scala/cmt/client/command/ListSavedStates.scala
+++ b/cmtc/src/main/scala/cmt/client/command/ListSavedStates.scala
@@ -43,8 +43,8 @@ object ListSavedStates:
         Right(toConsoleGreen(s"No saved states found\n"))
       else
         Right(
-        toConsoleGreen(s"Saved states available for exercises:\n") + toConsoleYellow(
-          s"${savedStates.mkString("\n   ", "\n   ", "\n")}"))
+          toConsoleGreen(s"Saved states available for exercises:\n") + toConsoleYellow(
+            s"${savedStates.mkString("\n   ", "\n   ", "\n")}"))
     }
 
   val command = new CmtcCommand[ListSavedStates.Options] {

--- a/cmtc/src/main/scala/cmt/client/command/PullSolution.scala
+++ b/cmtc/src/main/scala/cmt/client/command/PullSolution.scala
@@ -1,7 +1,7 @@
 package cmt.client.command
 
 import caseapp.{AppName, CommandName, ExtraName, HelpMessage, RemainingArgs}
-import cmt.{CMTcConfig, CmtError, printResult, toConsoleGreen}
+import cmt.{CMTcConfig, CmtError, printResult, toConsoleGreen, toConsoleYellow}
 import cmt.Helpers.{fileList, withZipFile}
 import cmt.client.Configuration
 import cmt.client.Domain.StudentifiedRepo
@@ -45,7 +45,7 @@ object PullSolution:
             config.solutionsFolder / currentExerciseId,
             config.activeExerciseFolder,
             preserveLastModified = true)
-          Right(toConsoleGreen(s"Pulled solution for $currentExerciseId"))
+          Right(toConsoleGreen(s"Pulled solution for ${toConsoleYellow(currentExerciseId)}"))
         }
       }
 

--- a/cmtc/src/main/scala/cmt/client/command/PullTemplate.scala
+++ b/cmtc/src/main/scala/cmt/client/command/PullTemplate.scala
@@ -60,7 +60,7 @@ object PullTemplate:
                   Right(toConsoleGreen(s"Pulled template folder: ") + toConsoleYellow(template.value))
             }
           }
-          .getOrElse(Left("Template name not supplied".toExecuteCommandErrorMessage))
+          .getOrElse(Left("No template name supplied".toExecuteCommandErrorMessage))
       }
 
   val command = new CmtcCommand[PullTemplate.Options] {

--- a/cmtc/src/main/scala/cmt/client/command/RestoreState.scala
+++ b/cmtc/src/main/scala/cmt/client/command/RestoreState.scala
@@ -53,7 +53,7 @@ object RestoreState:
                   preserveLastModified = true)
 
                 Helpers.writeStudentifiedCMTBookmark(config.bookmarkFile, exercise.value)
-                Right(toConsoleGreen(s"Restored state for ${exercise.value}"))
+                Right(toConsoleGreen(s"Restored state for ${toConsoleYellow(exercise.value)}"))
               }
             }
           }

--- a/cmtc/src/main/scala/cmt/client/command/SaveState.scala
+++ b/cmtc/src/main/scala/cmt/client/command/SaveState.scala
@@ -55,7 +55,7 @@ object SaveState:
           zipToFolder = savedStatesFolder,
           exercise = currentExerciseId)
 
-        Right(toConsoleGreen(s"Saved state for $currentExerciseId"))
+        Right(toConsoleGreen(s"Saved state for ${toConsoleYellow(currentExerciseId)}"))
       }
 
   val command = new CmtcCommand[SaveState.Options] {


### PR DESCRIPTION
- Print out a more meaningful message when `cmtc list-saved-states` is run and no previously saved states are available
- Make colouring of success messages consistent between commands