### PR TITLE
Harmonize short option for destination folder cmta

### DIFF
--- a/cmta/src/main/scala/cmt/admin/command/Delinearize.scala
+++ b/cmta/src/main/scala/cmt/admin/command/Delinearize.scala
@@ -19,7 +19,7 @@ object Delinearize:
   @CommandName("delinearize")
   @HelpMessage("'Delinearizes' an existing master repository")
   final case class Options(
-      @ExtraName("l")
+      @ExtraName("d")
       @ValueDescription("Folder which contains a 'linearized' repo of the main repo")
       linearizeBaseDirectory: LinearizeBaseDirectory,
       @Recurse shared: SharedOptions)

--- a/cmta/src/main/scala/cmt/admin/command/Linearize.scala
+++ b/cmta/src/main/scala/cmt/admin/command/Linearize.scala
@@ -19,7 +19,7 @@ object Linearize:
   @HelpMessage(
     "'Linearizes' a 'main' repository in the target directory where the linearized repo has one commit per exercise")
   final case class Options(
-      @ExtraName("l")
+      @ExtraName("d")
       @ValueDescription("Folder in which the 'linearized' repo will be created")
       linearizeBaseDirectory: LinearizeBaseDirectory,
       @ExtraName("f")

--- a/cmta/src/main/scala/cmt/admin/command/Studentify.scala
+++ b/cmta/src/main/scala/cmt/admin/command/Studentify.scala
@@ -25,7 +25,7 @@ object Studentify:
   @HelpMessage(
     "'Studentifies' an existing repository - taking the 'main' repository and creating a CMT project in the target directory")
   final case class Options(
-      @ExtraName("s")
+      @ExtraName("d")
       @ValueDescription("Folder in which the 'studentified' artifact will be created")
       studentifyBaseDirectory: StudentifyBaseDirectory,
       @ExtraName("f")

--- a/cmta/src/test/scala/cmt/admin/cli/DelinearizeArgumentsSpec.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/DelinearizeArgumentsSpec.scala
@@ -33,7 +33,7 @@ final class DelinearizeArgumentsSpec extends CommandLineArgumentsSpec[Delineariz
       (
         Seq.empty,
         Set(
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", nonExistentDirectory(tempDirectory)),
@@ -44,7 +44,7 @@ final class DelinearizeArgumentsSpec extends CommandLineArgumentsSpec[Delineariz
               ErrorMessage(s"$nonExistentFile does not exist"),
               ErrorMessage(s"$nonExistentFile is not a directory"),
               ErrorMessage(s"$nonExistentFile is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", realFile),
@@ -52,7 +52,7 @@ final class DelinearizeArgumentsSpec extends CommandLineArgumentsSpec[Delineariz
           FailedToValidateArgument(
             OptionName("m"),
             List(ErrorMessage(s"$realFile is not a directory"), ErrorMessage(s"$realFile is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", realFile),
@@ -60,24 +60,24 @@ final class DelinearizeArgumentsSpec extends CommandLineArgumentsSpec[Delineariz
           FailedToValidateArgument(
             OptionName("m"),
             List(ErrorMessage(s"$realFile is not a directory"), ErrorMessage(s"$realFile is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", tempDirectory.getAbsolutePath),
         Set(
           FailedToValidateArgument(OptionName("m"), List(ErrorMessage(s"$tempDirectory is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
-        Seq("-m", baseDirectoryGitRoot.getAbsolutePath, "-l", realFile),
+        Seq("-m", baseDirectoryGitRoot.getAbsolutePath, "-d", realFile),
         Set(
-          FailedToValidateArgument(OptionName("l"), List(ErrorMessage(s"$realFile is not a directory"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")))))
+          FailedToValidateArgument(OptionName("d"), List(ErrorMessage(s"$realFile is not a directory"))),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")))))
   }
 
   def validArguments(tempDirectory: File) = validArgumentsTable(
     (
-      Seq("-m", baseDirectoryGitRoot.getAbsolutePath, "-l", secondRealDirectory),
+      Seq("-m", baseDirectoryGitRoot.getAbsolutePath, "-d", secondRealDirectory),
       Delinearize.Options(
         linearizeBaseDirectory = LinearizeBaseDirectory(file(secondRealDirectory)),
         shared = SharedOptions(MainRepository(baseDirectoryGitRoot), maybeConfigFile = None))))

--- a/cmta/src/test/scala/cmt/admin/cli/LinearizeArgumentsSpec.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/LinearizeArgumentsSpec.scala
@@ -34,7 +34,7 @@ final class LinearizeArgumentsSpec extends CommandLineArgumentsSpec[Linearize.Op
       (
         Seq.empty,
         Set(
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", nonExistentDirectory(tempDirectory)),
@@ -45,7 +45,7 @@ final class LinearizeArgumentsSpec extends CommandLineArgumentsSpec[Linearize.Op
               ErrorMessage(s"$nonExistentFile does not exist"),
               ErrorMessage(s"$nonExistentFile is not a directory"),
               ErrorMessage(s"$nonExistentFile is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", realFile),
@@ -53,7 +53,7 @@ final class LinearizeArgumentsSpec extends CommandLineArgumentsSpec[Linearize.Op
           FailedToValidateArgument(
             OptionName("m"),
             List(ErrorMessage(s"$realFile is not a directory"), ErrorMessage(s"$realFile is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
         Seq("-m", tempDirectory.getAbsolutePath),
@@ -61,25 +61,25 @@ final class LinearizeArgumentsSpec extends CommandLineArgumentsSpec[Linearize.Op
           FailedToValidateArgument(
             OptionName("m"),
             List(ErrorMessage(s"${tempDirectory.getAbsolutePath} is not in a git repository"))),
-          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -l")),
+          RequiredOptionIsMissing(OptionName("--linearize-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))))
   }
 
   def validArguments(tempDirectory: File) = validArgumentsTable(
     (
-      Seq("-m", firstRealDirectory, "-l", secondRealDirectory),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory),
       Linearize.Options(
         linearizeBaseDirectory = LinearizeBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(false),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-l", secondRealDirectory, "--force-delete"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "--force-delete"),
       Linearize.Options(
         linearizeBaseDirectory = LinearizeBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(true),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-l", secondRealDirectory, "-f"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "-f"),
       Linearize.Options(
         linearizeBaseDirectory = LinearizeBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(true),

--- a/cmta/src/test/scala/cmt/admin/cli/StudentifyArgumentsSpec.scala
+++ b/cmta/src/test/scala/cmt/admin/cli/StudentifyArgumentsSpec.scala
@@ -37,10 +37,10 @@ final class StudentifyArgumentsSpec extends CommandLineArgumentsSpec[Studentify.
       (
         Seq.empty,
         Set(
-          RequiredOptionIsMissing(OptionName("--studentify-base-directory, -s")),
+          RequiredOptionIsMissing(OptionName("--studentify-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
-        Seq("-m", nonExistentDirectory(tempDirectory), "-s", nonExistentDirectory(tempDirectory)),
+        Seq("-m", nonExistentDirectory(tempDirectory), "-d", nonExistentDirectory(tempDirectory)),
         Set(
           FailedToValidateArgument(
             OptionName("m"),
@@ -49,27 +49,27 @@ final class StudentifyArgumentsSpec extends CommandLineArgumentsSpec[Studentify.
               ErrorMessage(s"$nonExistentFile is not a directory"),
               ErrorMessage(s"$nonExistentFile is not in a git repository"))),
           FailedToValidateArgument(
-            OptionName("s"),
+            OptionName("d"),
             List(
               ErrorMessage(s"$nonExistentFile does not exist"),
               ErrorMessage(s"$nonExistentFile is not a directory"))),
-          RequiredOptionIsMissing(OptionName("--studentify-base-directory, -s")),
+          RequiredOptionIsMissing(OptionName("--studentify-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
-        Seq("-m", realFile, "-s", nonExistentDirectory(tempDirectory)),
+        Seq("-m", realFile, "-d", nonExistentDirectory(tempDirectory)),
         Set(
           FailedToValidateArgument(
             OptionName("m"),
             List(ErrorMessage(s"$realFile is not a directory"), ErrorMessage(s"$realFile is not in a git repository"))),
           FailedToValidateArgument(
-            OptionName("s"),
+            OptionName("d"),
             List(
               ErrorMessage(s"$nonExistentFile does not exist"),
               ErrorMessage(s"$nonExistentFile is not a directory"))),
-          RequiredOptionIsMissing(OptionName("--studentify-base-directory, -s")),
+          RequiredOptionIsMissing(OptionName("--studentify-base-directory, -d")),
           RequiredOptionIsMissing(OptionName("--main-repository, -m")))),
       (
-        Seq("-m", tempDirectory.getAbsolutePath, "-s", secondRealDirectory),
+        Seq("-m", tempDirectory.getAbsolutePath, "-d", secondRealDirectory),
         Set(
           FailedToValidateArgument(
             OptionName("m"),
@@ -79,49 +79,49 @@ final class StudentifyArgumentsSpec extends CommandLineArgumentsSpec[Studentify.
 
   def validArguments(tempDirectory: File) = validArgumentsTable(
     (
-      Seq("-m", baseDirectoryGitRoot.getAbsolutePath, "-s", secondRealDirectory),
+      Seq("-m", baseDirectoryGitRoot.getAbsolutePath, "-d", secondRealDirectory),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(false),
         initGit = InitializeGitRepo(false),
         shared = SharedOptions(MainRepository(baseDirectoryGitRoot), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-s", secondRealDirectory, "--force-delete"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "--force-delete"),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(true),
         initGit = InitializeGitRepo(false),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-s", secondRealDirectory, "-f"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "-f"),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(true),
         initGit = InitializeGitRepo(false),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-s", secondRealDirectory, "--init-git"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "--init-git"),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(false),
         initGit = InitializeGitRepo(true),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-s", secondRealDirectory, "-g"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "-g"),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(false),
         initGit = InitializeGitRepo(true),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-s", secondRealDirectory, "--force-delete", "--init-git"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "--force-delete", "--init-git"),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(true),
         initGit = InitializeGitRepo(true),
         shared = SharedOptions(MainRepository(file(firstRealDirectory)), maybeConfigFile = None))),
     (
-      Seq("-m", firstRealDirectory, "-s", secondRealDirectory, "-f", "-g"),
+      Seq("-m", firstRealDirectory, "-d", secondRealDirectory, "-f", "-g"),
       Studentify.Options(
         studentifyBaseDirectory = StudentifyBaseDirectory(file(secondRealDirectory)),
         forceDelete = ForceDeleteDestinationDirectory(true),


### PR DESCRIPTION
- Commands `studentify`, `linearize`, and `delinearize` now use the same `-d` short option name to specifiy the studentified/linearized base folder